### PR TITLE
Removed hoot make

### DIFF
--- a/BuildArchive.sh
+++ b/BuildArchive.sh
@@ -80,7 +80,6 @@ rm -f /home/vagrant/hootenanny-rpms/src/SOURCES/hootenanny-*.tar.gz
 rm -f /home/vagrant/hootenanny-rpms/src/SOURCES/hootenanny-services*.war
 
 [ -e /tmp/words1.sqlite ] && cp /tmp/words1.sqlite conf/
-make -s -j `nproc`
 make -s -j `nproc` archive
 
 # Run the tests that are known to be good on CentOS with a generous timeout

--- a/BuildArchive.sh
+++ b/BuildArchive.sh
@@ -82,8 +82,5 @@ rm -f /home/vagrant/hootenanny-rpms/src/SOURCES/hootenanny-services*.war
 [ -e /tmp/words1.sqlite ] && cp /tmp/words1.sqlite conf/
 make -s -j `nproc` archive
 
-# Run the tests that are known to be good on CentOS with a generous timeout
-timeout 600s HootTest --exclude=.*RubberSheetConflateTest.sh --exclude=.*ConflateCmdHighwayExactMatchInputsTest.sh --slow
-
 cp -l hootenanny-[0-9]*.tar.gz /home/vagrant/hootenanny-rpms/src/SOURCES/
 cp -l hootenanny-services*.war /home/vagrant/hootenanny-rpms/src/SOURCES/

--- a/BuildArchive.sh
+++ b/BuildArchive.sh
@@ -12,7 +12,7 @@ echo $GIT_COMMIT
 
 export JAVA_HOME=/etc/alternatives/jre_1.7.0
 
-echo "%__make /usr/bin/make -j 4" >> /home/vagrant/.rpmmacros
+echo "%__make /usr/bin/make -sj4" >> /home/vagrant/.rpmmacros
 
 sudo yum install -y ccache
 

--- a/BuildArchive.sh
+++ b/BuildArchive.sh
@@ -12,6 +12,8 @@ echo $GIT_COMMIT
 
 export JAVA_HOME=/etc/alternatives/jre_1.7.0
 
+echo "%__make /usr/bin/make -j 4" >> /home/vagrant/.rpmmacros
+
 sudo yum install -y ccache
 
 cd /home/vagrant/hootenanny-rpms/src/


### PR DESCRIPTION
Refs ngageoint/hootenanny#472

Remove first hoot make because it isn't necessary in the RPM building process here.  Will be done later when the hoot binary RPM is built.