### PR TITLE
Omit OsmApiDb tests from RPM test VM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,13 @@ vagrant-clean:
 
 vagrant-test:
 	cd test; vagrant up
+	# OsmApiDb is being excluded b/c the RPM test environment doesn't include
+	# a OSM API DB.
 	cd test; vagrant ssh -c "cd /var/lib/hootenanny && sudo HootTest --diff \
 		--exclude=.*ConflateAverageTest.sh \
 		--exclude=.*RubberSheetConflateTest.sh \
 		--exclude=.*ConflateCmdHighwayExactMatchInputsTest.sh \
+		--exclude=.*OsmApiDb.* \
 		--slow"
 
 deps: force


### PR DESCRIPTION
1. refs https://github.com/ngageoint/hootenanny-rpms/issues/67