### PR TITLE
Upgrade FileGDB_API RPM from v1.3 to v1.4

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@ TARBALLS := $(wildcard SOURCES/hootenanny*.tar.gz)
 DOCBALLS := $(wildcard SOURCES/hootenanny*-documentation.tar.gz)
 HOOTBALL := $(filter-out $(DOCBALLS), $(TARBALLS))
 
-FILEGDB_RPM=RPMS/x86_64/FileGDB_API-1.3-1.el6.x86_64.rpm
+FILEGDB_RPM=RPMS/x86_64/FileGDB_API-1.4-1.el6.x86_64.rpm
 INSTALL_FILEGDB=yum list installed FileGDB_API || sudo yum -y install $(FILEGDB_RPM)
 # Synchronizing the make build with rpmbuild parallel flags causes problems. This way we
 # spawn at most nproc processes per sub-job and if the load is above nproc + 2 no more

--- a/src/SPECS/FileGDB_API.spec
+++ b/src/SPECS/FileGDB_API.spec
@@ -2,17 +2,17 @@
 ### This is far from complete. Just playing.
 ####
 Name:		FileGDB_API
-Version:	1.3
+Version:	1.4
 Release:	1%{?dist}
 Summary:	ESRI FileGDB libraries
 
 Group:		System Environment/Libraries
 License:	Copyright © 2012 ESRI
-URL:		http://www.esri.com/apps/products/download/#File_Geodatabase_API_1.3
+URL:		http://www.esri.com/apps/products/download/#File_Geodatabase_API_1.4
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 #Source0:        http://www.esri.com/apps/products/download/index.cfm?fuseaction=download.main&downloadid=841
-Source1:        FileGDB_API_1_3-64.tar.gz
+Source1:        FileGDB_API_1_4-64.tar.gz
 
 %description
 
@@ -52,10 +52,9 @@ email: contracts@esri.com
 /usr/share/*
 
 %prep
-mkdir -p %{name}-%{version}
-cd %{name}-%{version}
-tar xf %{_sourcedir}/FileGDB_API_1_3-64.tar.gz
-cd FileGDB_API
+mkdir -p %{name}-%{version}/FileGDB_API
+cd %{name}-%{version}/FileGDB_API
+tar xf %{_sourcedir}/FileGDB_API_1_4-64.tar.gz --strip-components 1
 
 %build
 true
@@ -82,5 +81,6 @@ install -D $BUILD_DIR/include/* $INSTALL_DIR/include/
 %clean
 
 %changelog
+* Thu Jan 19 2017 Benjamin Marchant <benjamin.marchant@digitalglobe.com>
 * Thu Jan 26 2016 Jason R. Surratt <jason.surratt@digitalglobe.com>
 - Initial attempt


### PR DESCRIPTION
Refs ngageoint/hootenanny#1335
Updated the FileGDB API RPM to use the latest version, v1.4
The latest `tar.gz` extracts to `FileGDB_API-64` vice `FileGDB_API` as before.  So it is easier to create the directory and then strip the directory name from the tar extraction.