### PR TITLE
Fix jdk requires to latest release

### DIFF
--- a/BuildArchive.sh
+++ b/BuildArchive.sh
@@ -11,7 +11,7 @@ fi
 echo $GIT_COMMIT
 
 #export JAVA_HOME=/etc/alternatives/jre_1.7.0
-#export JAVA_HOME=/usr/java/jdk1.8.0_111
+#export JAVA_HOME=/usr/java/jdk1.8.0_131
 export JAVA_HOME=/etc/alternatives/java_sdk
 
 echo "%__make /usr/bin/make -sj4" >> /home/vagrant/.rpmmacros

--- a/src/SOURCES/tomcat8.conf
+++ b/src/SOURCES/tomcat8.conf
@@ -10,7 +10,7 @@
 
 # This is the $JAVA_HOME of JDK, not JRE. not needed if you've setup
 # the file "/etc/profile.d/java.sh" with this variable.
-#export JAVA_HOME="/usr/java/jdk1.8.0_111"
+#export JAVA_HOME="/usr/java/jdk1.8.0_131"
 
 # Where your tomcat installation lives
 CATALINA_BASE="/usr/share/tomcat8"

--- a/src/SPECS/hootenanny.spec.in
+++ b/src/SPECS/hootenanny.spec.in
@@ -24,7 +24,7 @@ BuildRequires:  proj-devel protobuf-devel python-argparse python-devel qt-devel
 BuildRequires:  texlive libxslt
 BuildRequires:  gnuplot
 BuildRequires:  unzip v8-devel w3m wget words zip
-BuildRequires:  jdk1.8.0_111
+BuildRequires:  jdk1.8.0_131
 
 Source0:        %{name}-%{version}.tar.gz
 
@@ -63,7 +63,7 @@ This package contains the core algorithms and command line interface.
 
 %build
 source ./SetupEnv.sh
-export JAVA_HOME=/usr/java/jdk1.8.0_111
+export JAVA_HOME=/usr/java/jdk1.8.0_131
 #export JAVA_HOME=/etc/alternatives/java_sdk
 
 # Sort out the postgres version. We can't rely on having pg_config in our path
@@ -111,7 +111,7 @@ cp -R node-export-server/ $RPM_BUILD_ROOT/var/lib/hootenanny/node-export-server
 
 make install
 echo "export HOOT_HOME=/var/lib/hootenanny" > $RPM_BUILD_ROOT/etc/profile.d/hootenanny.sh
-echo "export JAVA_HOME=/usr/java/jdk1.8.0_111" >> $RPM_BUILD_ROOT/etc/profile.d/hootenanny.sh
+echo "export JAVA_HOME=/usr/java/jdk1.8.0_131" >> $RPM_BUILD_ROOT/etc/profile.d/hootenanny.sh
 
 chmod 755 $RPM_BUILD_ROOT/etc/profile.d/hootenanny.sh
 cp -R test-files/ $RPM_BUILD_ROOT/var/lib/hootenanny/
@@ -128,7 +128,7 @@ ln -s /usr/share/doc/hootenanny  $RPM_BUILD_ROOT/var/lib/hootenanny/docs
 
 %check
 source ./SetupEnv.sh
-export JAVA_HOME=/usr/java/jdk1.8.0_111
+export JAVA_HOME=/usr/java/jdk1.8.0_131
 #export JAVA_HOME=/etc/alternatives/java_sdk
 # The excluded tests are failing on CentOS now and waiting on a fix
 # https://github.com/ngageoint/hootenanny/issues/279
@@ -170,7 +170,7 @@ Requires:   postgresql-server >= 9.1
 Requires:   postgresql-contrib >= 9.1
 # NOTE: We need to look at postgis versions
 Requires:   postgis2_93 >= 2.1
-Requires:   jdk1.8.0_111
+Requires:   jdk1.8.0_131
 Requires:   liquibase
 Requires:   pwgen
 Group:      Applications/Engineering
@@ -212,19 +212,19 @@ if [ "$1" = "2" ]; then
     fi
 fi
 
-# Setting /usr/java/jdk1.8.0_111/bin/java's priority to something really atrocious to guarantee that it will be
+# Setting /usr/java/jdk1.8.0_131/bin/java's priority to something really atrocious to guarantee that it will be
 # the one used when alternatives' auto mode is used.
-sudo alternatives --install /usr/bin/java java /usr/java/jdk1.8.0_111/bin/java 999999
+sudo alternatives --install /usr/bin/java java /usr/java/jdk1.8.0_131/bin/java 999999
 
-# Setting /usr/java/jdk1.8.0_111/bin/javac's priority to something really atrocious to guarantee that it will be
+# Setting /usr/java/jdk1.8.0_131/bin/javac's priority to something really atrocious to guarantee that it will be
 # the one used when alternatives' auto mode is enabled.
-sudo alternatives --install /usr/bin/javac javac /usr/java/jdk1.8.0_111/bin/javac 9999999
+sudo alternatives --install /usr/bin/javac javac /usr/java/jdk1.8.0_131/bin/javac 9999999
 
 # switching to manual and forcing the desired version of java be configured
-sudo alternatives --set java /usr/java/jdk1.8.0_111/bin/java
+sudo alternatives --set java /usr/java/jdk1.8.0_131/bin/java
 
 # switching to manual and forcing the desired version of javac be configured
-sudo alternatives --set javac /usr/java/jdk1.8.0_111/bin/javac
+sudo alternatives --set javac /usr/java/jdk1.8.0_131/bin/javac
 
 
 %post services-ui
@@ -321,7 +321,7 @@ EOT
     sudo sed -i s/\<Password\>hoottest\<\\/Password\>/\<Password\>$DB_PASSWORD\<\\/Password\>/ /var/lib/tomcat8/webapps/hoot-services/WEB-INF/workspace/jdbc/WFS_Connection.xml
 
     # make sure tomcat is using correct Java
-    sudo sed -i '/.*JAVA_HOME=.*/c\JAVA_HOME=\/usr\/java\/jdk1.8.0_111' /etc/tomcat8/tomcat8.conf
+    sudo sed -i '/.*JAVA_HOME=.*/c\JAVA_HOME=\/usr\/java\/jdk1.8.0_131' /etc/tomcat8/tomcat8.conf
 
     sudo service tomcat8 restart
 }

--- a/src/SPECS/tomcat8.spec
+++ b/src/SPECS/tomcat8.spec
@@ -27,7 +27,7 @@ Source2:    %{name}.sysconfig
 Source3:    %{name}.logrotate
 Source4:    %{name}.conf
 Requires:   jpackage-utils
-Requires:   jdk1.8.0_111
+Requires:   jdk1.8.0_131
 BuildRoot:  %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 %description


### PR DESCRIPTION
References #144.

There was some references I missed the first round.  It still worked before because of jdk_111 being cached in the git working directory.  Once it's removed, then build failures happen.

This is a little out of the normal workflow since we are mid release.  I'd like to go straight into master then merge it into develop.