### PR TITLE
Hootenanny Spec Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ hoot-rpm: $(BUILD_IMAGE)
 	$(VAGRANT) docker-run $(BUILD_IMAGE) -- \
 	rpmbuild \
 	  --define "hoot_version_gen $(HOOT_VERSION_GEN)" \
-	  --define "geos_version %(rpm -q --queryformatn '%%{version} geos)" \
+	  --define "geos_version %(rpm -q --queryformat '%%{version}' geos)" \
 	  --define "gdal_version %(rpm -q --queryformat '%%{version}' hoot-gdal)" \
 	  --define "glpk_version %(rpm -q --queryformat '%%{version}' glpk)" \
 	  --define "nodejs_version %(rpm -q --queryformat '%%{version}' nodejs)" \

--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -201,6 +201,7 @@ After=syslog.target network.target
 Type=simple
 User=tomcat
 Group=tomcat
+Environment='HOOT_HOME=%{hoot_home}'
 WorkingDirectory=%{hoot_home}/node-export-server
 ExecStart=/usr/bin/npm start
 ExecStop=/usr/bin/kill -HUP \$MAINPID

--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -763,7 +763,7 @@ Requires:  boost-devel
 Requires:  cppunit-devel
 Requires:  gcc-c++
 Requires:  gdb
-Requires:  geos-devel
+Requires:  geos-devel = %{geos_version}
 Requires:  git
 Requires:  glpk-devel = %{glpk_version}
 Requires:  hoot-words
@@ -813,7 +813,7 @@ Requires:  boost-system
 Requires:  cppunit
 Requires:  dblatex
 Requires:  FileGDBAPI
-Requires:  geos
+Requires:  geos = %{geos_version}
 Requires:  glpk = %{glpk_version}
 Requires:  gnuplot
 Requires:  graphviz

--- a/shell/BuildHoot.sh
+++ b/shell/BuildHoot.sh
@@ -18,9 +18,10 @@ set -u
 run_hoot_build_image \
     -i $BUILD_IMAGE \
     rpmbuild \
-      --define "glpk_version %(rpm -q --queryformat '%%{version}' glpk)" \
-      --define "gdal_version %(gdal-config --version)" \
       --define "hoot_version_gen ${HOOT_VERSION_GEN}" \
+      --define "geos_version %(rpm -q --queryformat '%%{version}' geos)" \
+      --define "glpk_version %(rpm -q --queryformat '%%{version}' glpk)" \
+      --define "gdal_version %(rpm -q --queryformat '%%{version}' hoot-gdal)" \
       --define "nodejs_version %(rpm -q --queryformat '%%{version}' nodejs)" \
       --define "stxxl_version %(rpm -q --queryformat '%%{version}' stxxl)" \
       --define "tomcat_version %(rpm -q --queryformat '%%{version}' tomcat8)" \


### PR DESCRIPTION
This fixes various errata with `hootenanny.spec` related to dependency churn since the 0.2.38 release:

* 71c1f3f: Disable installing the `node-mapnik-server` code and service until it's fixed, see ngageoint/hootenanny#2111.  This prevented building of the Hootenanny RPM completely.
* 75b9545: Add `HOOT_HOME` environment variable to the `node-export` unit file, see ngageoint/hootenanny#2151.
* 600b504: Lock Hootenanny RPMs to explicitly require the exact GEOS version, complements 3.6.2 upgrade in ngageoint/hootenanny#2176.