### PR TITLE
Tomcat 8.5.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ make hoot-archive
 make hoot-rpm
 ```
 
+Note: it's common for the `hoot-archive` target to fail the first time due to
+maven downloading outside dependencies.
+
 ## shell
 
 Scripts in the [`shell`](./shell) directory can be used to build the RPMs

--- a/SPECS/tomcat8.spec
+++ b/SPECS/tomcat8.spec
@@ -191,8 +191,12 @@ getent passwd %{tomcat_user} 2>/dev/null || \
 %systemd_postun %{name}.service
 
 %changelog
-* Fri Jan 12 2018 Justin Bronn <justin.bronn@digitalglobe.com> - 8.5.24-1
-- Upgrade to 8.5.24.
-- Replaced init script with systemd units.
-* Wed Nov 15 2017 Justin Bronn <justin.bronn@digitalglobe.com> - 8.5.23-1
-- Initial release.
+* Mon Feb 26 2018 Justin Bronn <justin.bronn@radiantsolutions.com> - 8.5.28-1
+- Upgrade to 8.5.28
+
+* Fri Jan 12 2018 Justin Bronn <justin.bronn@radiantsolutions.com> - 8.5.24-1
+- Upgrade to 8.5.24
+- Replaced init script with systemd units
+
+* Wed Nov 15 2017 Justin Bronn <justin.bronn@radiantsolutions.com> - 8.5.23-1
+- Initial release

--- a/config.yml
+++ b/config.yml
@@ -15,7 +15,7 @@ versions:
   postgresql: &pg_version '9.5'
   stxxl: &stxxl_version '1.3.1-1'
   su-exec: &suexec_version '0.2-1'
-  tomcat8: &tomcat8_version '8.5.24-1'
+  tomcat8: &tomcat8_version '8.5.28-1'
   wamerican-insane: &wamerican_version '7.1-1'
 
 

--- a/doc/verify.md
+++ b/doc/verify.md
@@ -1,0 +1,42 @@
+# Verify Sources
+
+Prior to adding source tarballs into this repository, they must be verified
+with known checksums.  If a cryptographic (GPG) signature is available, then
+it must be used.  Below are instructions for verifying some of Hootenanny's
+dependencies from upstream sources.
+
+## GLPK
+
+GLPK is [maintained by Andrew Makhorin](https://www.gnu.org/software/glpk/glpk.html#maintainer)
+and the tarball may be verified with his key:
+
+```
+pushd SOURCES
+gpg --keyserver keys.gnupg.net --recv-keys D17BF2305981E818
+curl -O https://ftp.gnu.org/gnu/glpk/glpk-$GLPK_VERSION.tar.gz
+curl -O https://ftp.gnu.org/gnu/glpk/glpk-$GLPK_VERSION.tar.gz.sig
+gpg --verify glpk-$GLPK_VERSION.tar.gz.sig
+popd
+```
+
+## Tomcat
+
+There are several Tomcat 8 maintainers that have release privileges; all of these
+keys are available in a [`KEYS`](https://www.apache.org/dist/tomcat/tomcat-8/KEYS) file
+available on their website, and all may be imported with this command:
+
+```
+curl https://www.apache.org/dist/tomcat/tomcat-8/KEYS | gpg --import
+```
+
+For the paranoid, it seems that only the keys for Mark Thomas is used for the
+recent 8.5 releases, thus it's possible to verify with only his key:
+
+```
+pushd SOURCES
+gpg --keyserver keys.gnupg.net --recv-keys 6FB21E8933C60243
+curl -O http://www.apache.org/dist/tomcat/tomcat-8/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+curl -O http://www.apache.org/dist/tomcat/tomcat-8/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
+gpg --verify apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
+popd
+```


### PR DESCRIPTION
* Upgrades our Tomcat RPM to 8.5.28.
* Add documentation for verifying some of our upstream dependency sources.