### PR TITLE
Maven Cache and Bugfixes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -19,6 +19,11 @@ versions:
   wamerican-insane: &wamerican_version '7.1-1'
 
 
+maven:
+  cache_url: &maven_cache_url 'https://s3.amazonaws.com/hoot-repo/maven/m2-cache.tar.gz'
+  cache_sha1: &maven_cache_sha1 'efbd6edd5a13bf3806780f144b4fe314c34eccfc'
+
+
 images:
   base: !!omap
     - rpmbuild:

--- a/config.yml
+++ b/config.yml
@@ -20,7 +20,7 @@ versions:
 
 
 maven:
-  cache_url: &maven_cache_url 'https://s3.amazonaws.com/hoot-repo/maven/m2-cache.tar.gz'
+  cache_url: &maven_cache_url 'https://s3.amazonaws.com/hoot-maven/m2-cache.tar.gz'
   cache_sha1: &maven_cache_sha1 'efbd6edd5a13bf3806780f144b4fe314c34eccfc'
 
 

--- a/doc/maven.md
+++ b/doc/maven.md
@@ -12,10 +12,23 @@ tar \
   -czvf ~/m2-cache.tar.gz repository
 ```
 
-Then uploaded as part of a `maven` directory to the `hoot-repo` S3 bucket:
+The resulting tar file is then uploaded to the `hoot-maven` S3 bucket,
+created with the following command:
 
 ```
-mkdir maven
-mv m2-cache.tar.gz maven
-aws s3 sync maven/ s3://hoot-repo/maven/ --acl public-read
+aws s3api create-bucket --bucket hoot-maven --acl public-read
+```
+
+Finally, copy the cache file to the bucket:
+
+```
+aws s3 cp m2-cache.tar.gz s3://hoot-maven/ --acl public-read
+```
+
+Please record the URL of the cache file and the SHA1 checksum in `config.yml`:
+
+```yaml
+maven:
+  cache_url: &maven_cache_url 'https://s3.amazonaws.com/hoot-maven/m2-cache.tar.gz'
+  cache_sha1: &maven_cache_sha1 'efbd6edd5a13bf3806780f144b4fe314c34eccfc'
 ```

--- a/doc/maven.md
+++ b/doc/maven.md
@@ -1,0 +1,21 @@
+# Maven Cache
+
+The Maven cache file was created with the following tar command:
+
+```
+tar \
+  --owner 1000 \
+  --group 1000 \
+  --numeric-owner \
+  --exclude repository/hoot \
+  -C ~/hootenanny-rpms/cache/m2 \
+  -czvf ~/m2-cache.tar.gz repository
+```
+
+Then uploaded as part of a `maven` directory to the `hoot-repo` S3 bucket:
+
+```
+mkdir maven
+mv m2-cache.tar.gz maven
+aws s3 sync maven/ s3://hoot-repo/maven/ --acl public-read
+```

--- a/shell/Vars.sh
+++ b/shell/Vars.sh
@@ -192,7 +192,9 @@ function build_run_images() {
 
 function maven_cache() {
     if ! test -d $CACHE/m2/repository; then
+        echo 'Downloading Maven cache'
         curl -sSL -o /var/tmp/m2-cache.tar.gz $MAVEN_CACHE_URL
+        echo 'Extracting Maven cache'
         echo "${MAVEN_CACHE_SHA1}  /var/tmp/m2-cache.tar.gz" | sha1sum -c -
         tar -C $CACHE/m2 -xzf /var/tmp/m2-cache.tar.gz
     fi

--- a/shell/Vars.sh
+++ b/shell/Vars.sh
@@ -273,7 +273,7 @@ function run_hoot_build_image() {
     if [ "${usage}" = "yes" ]; then
         echo "run_hoot_build_image: [-e <entrypoint>] [-i <image>] [-u <user>]"
     else
-        mkdir -p $SCRIPT_HOME/hootenanny $CACHE/m2 $CACHE/npm
+        mkdir -p $SCRIPT_HOME/hootenanny $RPMS $CACHE/m2 $CACHE/npm
         maven_cache
         docker run \
                -v $SOURCES:/rpmbuild/SOURCES:$sources_mode \

--- a/shell/Vars.sh
+++ b/shell/Vars.sh
@@ -193,7 +193,7 @@ function build_run_images() {
 function maven_cache() {
     if ! test -d $CACHE/m2/repository; then
         curl -sSL -o /var/tmp/m2-cache.tar.gz $MAVEN_CACHE_URL
-        echo "${MAVEN_CACHE_SHA1}  /var/tmp/m2-cache.tar.gz" | shasum -c -
+        echo "${MAVEN_CACHE_SHA1}  /var/tmp/m2-cache.tar.gz" | sha1sum -c -
         tar -C $CACHE/m2 -xzf /var/tmp/m2-cache.tar.gz
     fi
 }

--- a/shell/Vars.sh
+++ b/shell/Vars.sh
@@ -1,8 +1,8 @@
-# The rpm apt package is required when on Ubuntu because we treat the
+# The rpm-build apt package is required when on Ubuntu because we treat the
 # *.spec files as a source of truth for version information and
 # `rpm` and `rpmspec` are necessary to intrepret them from macros.
-if ! test -x /usr/bin/rpm; then
-    echo "This script requires the 'rpm' package."
+if ! test -x /usr/bin/rpmbuild; then
+    echo "This script requires the 'rpm' package (Ubuntu) or 'rpm-build' (CentOS)"
     exit 1
 fi
 


### PR DESCRIPTION
Fixes #177 by having Vagrant and the shell scripts download a tar archive containing a `repository` that is preseeded with Hootenanny services Java dependencies.

Additional fixes:

7c50b9b: Create `RPMS` folder as invoking user in `run_hoot_build_image` function; an error that @Cellington1 was probably encountering.

b80ec97: Look for `rpmbuild` instead of `rpm` and improve error message.