### PR TITLE
Fix RPM Upgrades

### DIFF
--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -659,32 +659,37 @@ to run Hootenanny.
 
 if test -f /.dockerenv; then exit 0; fi
 
-# set Postgres to autostart
-systemctl enable postgresql-%{pg_version}
-# set Tomcat to autostart
-systemctl enable tomcat8
-# set NodeJS node-export-server to autostart
-systemctl enable node-export
+if [ "$1" = "1" ]; then
+    # set Postgres to autostart
+    systemctl enable postgresql-%{pg_version}
+    # set Tomcat to autostart
+    systemctl enable tomcat8
+    # set NodeJS node-export-server to autostart
+    systemctl enable node-export
 %if 0%{with_node_mapnik} == 1
-# set NodeJS node-mapnik-server to autostart
-systemctl enable node-mapnik
+    # set NodeJS node-mapnik-server to autostart
+    systemctl enable node-mapnik
 %endif
+fi
+
 
 
 %postun autostart
 
 if test -f /.dockerenv; then exit 0; fi
 
-# set Postgres to NOT autostart
-systemctl disable postgresql-%{pg_version}
-# set Tomcat to NOT autostart
-systemctl disable tomcat8
-# set NodeJS node-export-server to NOT autostart
-systemctl disable node-export
+if [ "$1" = "0" ]; then
+    # set Postgres to NOT autostart
+    systemctl disable postgresql-%{pg_version}
+    # set Tomcat to NOT autostart
+    systemctl disable tomcat8
+    # set NodeJS node-export-server to NOT autostart
+    systemctl disable node-export
 %if 0%{with_node_mapnik} == 1
-# set NodeJS node-mapnik-server to NOT autostart
-systemctl disable node-mapnik
+    # set NodeJS node-mapnik-server to NOT autostart
+    systemctl disable node-mapnik
 %endif
+fi
 
 
 %package services-devel-deps

--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -382,7 +382,8 @@ This package contains the UI and web services.
 %pre services-ui
 
 if [ "$1" = "2" ]; then
-    # Perform whatever maintenance must occur before the upgrade
+    # Stop tomcat8 service before removing the extracted war files.
+    systemctl stop tomcat8
 
     # Remove exploded hoot-services war remnants
     if [ -d %{services_home} ]; then
@@ -607,9 +608,8 @@ if [ "$1" = "0" ]; then
     done
 
     # Remove .deegree directory
-    TOMCAT_HOME=%{tomcat_home}
-    if [ -d $TOMCAT_HOME/.deegree ]; then
-        rm -rf $TOMCAT_HOME/.deegree
+    if [ -d %{tomcat_home}/.deegree ]; then
+        rm -rf %{tomcat_home}/.deegree
     fi
 
     # Remove exploded hoot-services war remnants

--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -390,7 +390,7 @@ if [ "$1" = "2" ]; then
     fi
 fi
 
-%preun
+%preun services-ui
 
 %systemd_preun node-export.service
 %if 0%{with_node_mapnik} == 1

--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -411,7 +411,7 @@ function startTomcat() {
     local count=0
     local timeout=180
     local deploy_pattern='org\.apache\.catalina\.startup\.HostConfig\.deployWAR Deployment of web application archive \[%{tomcat_webapps}/hoot-services.war\] has finished'
-    local start_time=$(date -u +'%Y-%m-%d %H:%M:%S')
+    local start_time=$(date +'%%Y-%%m-%%d %%H:%%M:%%S')
 
     systemctl start tomcat8
 

--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -37,6 +37,7 @@
 %{!?tomcat_home: %global tomcat_home %{_datadir}/tomcat8}
 %{!?tomcat_logs: %global tomcat_logs %{_var}/log/tomcat8}
 %global tomcat_webapps %{tomcat_basedir}/webapps
+%global services_home %{tomcat_webapps}/hoot-services
 
 # NodeJS package includes an epoch that must be used for requirements.
 %{!?nodejs_epoch: %global nodejs_epoch 1}
@@ -384,9 +385,8 @@ if [ "$1" = "2" ]; then
     # Perform whatever maintenance must occur before the upgrade
 
     # Remove exploded hoot-services war remnants
-    SERVICES_HOME=%{tomcat_webapps}/hoot-services
-    if [ -d $SERVICES_HOME ]; then
-        rm -rf $SERVICES_HOME
+    if [ -d %{services_home} ]; then
+        rm -rf %{services_home}
     fi
 fi
 
@@ -613,9 +613,8 @@ if [ "$1" = "0" ]; then
     fi
 
     # Remove exploded hoot-services war remnants
-    SERVICES_HOME=%{tomcat_webapps}/hoot-services
-    if [ -d $SERVICES_HOME ]; then
-        rm -rf $SERVICES_HOME
+    if [ -d %{services_home} ]; then
+        rm -rf %{services_home}
     fi
 
     systemctl start tomcat8

--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -468,10 +468,16 @@ function updateLiquibase () {
         sed -i "1 s/$/ $(hostname)/" /etc/hosts
     fi
 
+    # Ensure that tomcat has unpacked hoot-services.war prior to
+    # running liquibase.
+    echo -n 'Waiting for tomcat to start'
+    while ! test -d %{tomcat_webapps}/hoot-services/WEB-INF; do
+        sleep 1
+    done
+
     # Apply any database schema changes
-    TOMCAT_HOME=%{tomcat_home}
     source %{hoot_home}/conf/database/DatabaseConfig.sh
-    cd $TOMCAT_HOME/webapps/hoot-services/WEB-INF
+    cd %{tomcat_webapps}/hoot-services/WEB-INF
     liquibase --contexts=default,production \
         --changeLogFile=classes/db/db.changelog-master.xml \
         --promptForNonLocalDatabase=false \

--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -429,18 +429,6 @@ function updateConfigFiles () {
         sed -i "s@<\/Host>@      <Context docBase=\""${HOOT_HOME//\//\\\/}"\/userfiles\/ingest\/processed\" path=\"\/static\" \/>\n      &@" $TOMCAT_SRV
     fi
 
-    # Allow linking in Tomcat context
-    TOMCAT_CTX=%{tomcat_config}/context.xml
-
-    # First, fix potential pre-existing setting of 'allowLinking' that doesn't work on tomcat8
-    sed -i "s@^<Context allowLinking=\"true\">@<Context>@" $TOMCAT_CTX
-
-    # Now, set allowLinking if needed
-    if ! grep -i --quiet 'allowLinking="true"' $TOMCAT_CTX; then
-        echo "Set allowLinking to true in Tomcat context"
-        sed -i "/<Context>/a \    <Resources allowLinking=\"true\" />" $TOMCAT_CTX
-    fi
-
     # Increase the Tomcat java heap size
     TOMCAT_CONF=%{tomcat_config}/tomcat8.conf
     if ! grep -i --quiet 'Xmx2048m' $TOMCAT_CONF; then


### PR DESCRIPTION
Fixes #179.  

RPM upgrades weren't working because during the `%pre` script section of the `hootenanny-services-ui` package the expanded contents of `hoot-services.war` were forcibly removed, and by the time either `updateConfigFiles` or `updateLiquibase` functions were executed, the `tomcat8` service would still be in the process of expanding the upgraded war.  This manifested in a variety of different errors, typically about missing database changeset files (for `updateLiquibase`) or missing properties files when calling `sed` (for `updateConfigFiles`).

The solution was to create a new function, `startTomcat` that would start the `tomcat8` service and wait for the all of the war files to be extracted before returning.  The function would query the systemd log since the time of service start and `grep` for the message that indicated the war had finished deploying.   If this isn't complete in 3 minutes, then the operation is aborted (typically it takes no more than 10 seconds at max).

In the process a few other bugs were found and fixed, along with some minor cleanup:
*  e632168: `hootenanny-autostart` upgrades would always cause the services to be enabled in `%post` and disabled in `%postun` (which is run *after* new package is installed to cleanup the old package).  The effect being that all Hootenanny services would be disabled on an upgrade -- this is true for our currently released RPMS, unless they are rebuilt.
* 74bfdb1: The `%preun` script for `hootenanny-services-ui` wasn't specified correctly.