### PR TITLE
Loosen Tomcat Version Requirements

### DIFF
--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -36,8 +36,8 @@
 %{!?tomcat_config: %global tomcat_config %{_sysconfdir}/tomcat8}
 %{!?tomcat_home: %global tomcat_home %{_datadir}/tomcat8}
 %{!?tomcat_logs: %global tomcat_logs %{_var}/log/tomcat8}
-%{!?tomcat_version_max %global tomcat_version_max %(echo %{tomcat_version} | %{__awk} -F. '{ print $1 "." ($2 + 1) "." 0 }')}
-%{!?tomcat_version_min %global tomcat_version_min %(echo %{tomcat_version} | %{__awk} -F. '{ print $1 "." $2 "." 0 }')}
+%global tomcat_version_max %(echo %{tomcat_version} | %{__awk} -F. '{ print $1 "." ($2 + 1) "." 0 }')
+%global tomcat_version_min %(echo %{tomcat_version} | %{__awk} -F. '{ print $1 "." $2 "." 0 }')
 %global tomcat_webapps %{tomcat_basedir}/webapps
 %global services_home %{tomcat_webapps}/hoot-services
 

--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -36,6 +36,8 @@
 %{!?tomcat_config: %global tomcat_config %{_sysconfdir}/tomcat8}
 %{!?tomcat_home: %global tomcat_home %{_datadir}/tomcat8}
 %{!?tomcat_logs: %global tomcat_logs %{_var}/log/tomcat8}
+%{!?tomcat_version_max %global tomcat_version_max %(echo %{tomcat_version} | %{__awk} -F. '{ print $1 "." ($2 + 1) "." 0 }')}
+%{!?tomcat_version_min %global tomcat_version_min %(echo %{tomcat_version} | %{__awk} -F. '{ print $1 "." $2 "." 0 }')}
 %global tomcat_webapps %{tomcat_basedir}/webapps
 %global services_home %{tomcat_webapps}/hoot-services
 
@@ -333,7 +335,8 @@ Requires:  osmosis
 Requires:  postgresql%{pg_dotless}-contrib
 Requires:  postgresql%{pg_dotless}-server
 Requires:  pwgen
-Requires:  tomcat8 = %{tomcat_version}
+Requires:  tomcat8 < %{tomcat_version_max}
+Requires:  tomcat8 >= %{tomcat_version_min}
 
 %description services-ui
 Hootenanny was developed to provide an open source, standards-based approach to

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -123,11 +123,12 @@ def build_container(config, name, options)
         # Fill out dummy macros so `rpmspec` won't choke.
         rpmspec_cmd = ['rpmspec', '-q', '--buildrequires']
         {
+          '_topdir' => File.realpath(File.dirname(__FILE__)),
+          'hoot_version_gen' => '0.0.0',
           'rpmbuild_version' => '0.0.0',
           'rpmbuild_release' => '0.0.0',
-          'hoot_version_gen' => '0.0.0',
           'pg_dotless' => $pg_dotless,
-          '_topdir' => File.realpath(File.dirname(__FILE__)),
+          'tomcat_version'   => '0.0.0',
         }.each do |macro, expr|
           rpmspec_cmd << '--define'
           # Have to put in single quotes surrounding macro since this is a


### PR DESCRIPTION
Fixes #182 by only locking to the major and minor versions defined in `tomcat_version`.  Currently, this means the `hootenanny-services-ui` RPM can use the latest 8.5 version.