### PR TITLE
Fix Regressions from 184

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -125,10 +125,10 @@ def build_container(config, name, options)
         {
           '_topdir' => File.realpath(File.dirname(__FILE__)),
           'hoot_version_gen' => '0.0.0',
-          'rpmbuild_version' => '0.0.0',
-          'rpmbuild_release' => '0.0.0',
           'pg_dotless' => $pg_dotless,
-          'tomcat_version'   => '0.0.0',
+          'rpmbuild_version' => '0.0.0',
+          'rpmbuild_release' => '1',
+          'tomcat_version' => '0.0.0',
         }.each do |macro, expr|
           rpmspec_cmd << '--define'
           # Have to put in single quotes surrounding macro since this is a

--- a/shell/Vars.sh
+++ b/shell/Vars.sh
@@ -50,6 +50,7 @@ function spec_requires() {
         --define "pg_dotless ${PG_DOTLESS}" \
         --define 'rpmbuild_version 0.0.0' \
         --define 'rpmbuild_release 1' \
+        --define 'tomcat_version 0.0.0' \
         -q --buildrequires $SPECS/$1.spec | \
         awk '{ for (i = 1; i <= NF; ++i) if ($i ~ /^[[:alpha:]]/) print $i }' ORS=' '
 }


### PR DESCRIPTION
Fixes regressions introduced from #184, specifically it was necessary to add in a dummy `tomcat_version` define in the `spec_requires()` shell function (like what was done in the `Vagrantfile`).