### PR TITLE
S3 Repository Sync

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git/*
 .vagrant/*
+cache/*
 el7/*
 el7-src/*
 hootenanny

--- a/Makefile
+++ b/Makefile
@@ -126,11 +126,12 @@ RUN_IMAGE ?= run-base-release
 
 # Are there any archives?
 HOOT_VERSION_GEN ?= $(call latest_hoot_version_gen)
+DEFAULT_ARCHIVE := SOURCES/hootenanny-archive.tar.gz
 
 ifeq ($(strip $(HOOT_VERSION_GEN)),)
 # Setup a dummy archive file that will force making of an archive
 # from the revision specified in GIT_COMMIT.
-HOOT_ARCHIVE := SOURCES/hootenanny-archive.tar.gz
+HOOT_ARCHIVE := $(DEFAULT_ARCHIVE)
 # don't define `HOOT_VERSION`, or `HOOT_RPM`.
 $(warning HOOT_VERSION_GEN is not defined)
 else
@@ -157,6 +158,7 @@ endif
 	deps \
 	hoot-archive \
 	hoot-rpm \
+	latest-archive \
 	rpm \
 	$(BUILD_CONTAINERS) \
 	$(DEPENDENCY_CONTAINERS) \
@@ -166,7 +168,7 @@ endif
 
 all: $(BUILD_CONTAINERS)
 
-archive: hoot-archive
+archive: $(BUILD_IMAGE) $(HOOT_ARCHIVE)
 
 base: $(BASE_CONTAINERS)
 
@@ -178,18 +180,20 @@ deps: \
 	$(DEPENDENCY_CONTAINERS) \
 	$(DEPENDENCY_RPMS)
 
-hoot-archive: $(BUILD_IMAGE) $(HOOT_ARCHIVE)
+hoot-archive: archive
+
+latest-archive: $(DEFAULT_ARCHIVE)
 
 # Only allow building an RPM when an archive already exists corresponding
 # to the HOOT_VERSION_GEN.
 ifdef HOOT_RPM
-hoot-rpm: $(BUILD_IMAGE) $(HOOT_RPM)
+rpm: $(BUILD_IMAGE) $(HOOT_RPM)
 else
-hoot-rpm:
+rpm:
 	$(error Cannot build RPM without an input archive.  Run 'make hoot-archive' first)
 endif
 
-rpm: hoot-rpm
+hoot-rpm: rpm
 
 ## Container targets.
 

--- a/docker/Dockerfile.rpmbuild-repo
+++ b/docker/Dockerfile.rpmbuild-repo
@@ -11,9 +11,18 @@ ARG gpg_name="Hootenanny Packaging"
 RUN yum install -q -y epel-release createrepo rpm-sign && \
     yum install -q -y awscli
 
+# Add in the `keepnewer` Python module plugin for awscli;
+# for `aws s3 sync --keep-newer` functionality.
+COPY scripts/keepnewer.py /usr/lib/python2.7/site-packages/
+
 # Use unprivleged RPM build user and work directory by default.
 USER ${RPMBUILD_USER}
 WORKDIR ${RPMBUILD_HOME}
+
+# Create stub awscli configuration and enable the keepnewer plugin.
+RUN mkdir -p $RPMBUILD_HOME/.aws && \
+    printf "[default]\nregion=${AWS_DEFAULT_REGION:-us-east-1}\n\n" > $RPMBUILD_HOME/.aws/config && \
+    printf "[plugins]\nkeepnewer=keepnewer\n\n" >> $RPMBUILD_HOME/.aws/config
 
 # Add RPM signing macros to ~/.rpmmacros, specifying:
 #  * The signing digest algorithm (defaulting to sha256)

--- a/docker/Dockerfile.rpmbuild-repo
+++ b/docker/Dockerfile.rpmbuild-repo
@@ -7,12 +7,13 @@ LABEL \
 
 ARG gpg_name="Hootenanny Packaging"
 
-# Install RPM repository and AWS CLI tools.
+# Install RPM repository and AWS CLI tools (via pip for latest version)
 RUN yum install -q -y epel-release createrepo rpm-sign && \
-    yum install -q -y awscli
+    yum install -q -y python2-pip && \
+    pip install -q --prefix /usr awscli
 
-# Add in the `keepnewer` Python module plugin for awscli;
-# for `aws s3 sync --keep-newer` functionality.
+# Add in the `keepnewer` Python (2.x on CentOS 7) module plugin for awscli;
+# enables `aws s3 sync --keep-newer` functionality.
 COPY scripts/keepnewer.py /usr/lib/python2.7/site-packages/
 
 # Use unprivleged RPM build user and work directory by default.

--- a/docker/Dockerfile.rpmbuild-repo
+++ b/docker/Dockerfile.rpmbuild-repo
@@ -8,7 +8,7 @@ LABEL \
 ARG gpg_name="Hootenanny Packaging"
 
 # Install RPM repository and AWS CLI tools (via pip for latest version)
-RUN yum install -q -y epel-release createrepo rpm-sign && \
+RUN yum install -q -y createrepo epel-release groff rpm-sign && \
     yum install -q -y python2-pip && \
     pip install -q --prefix /usr awscli
 

--- a/docker/Dockerfile.rpmbuild-repo
+++ b/docker/Dockerfile.rpmbuild-repo
@@ -8,7 +8,7 @@ LABEL \
 ARG gpg_name="Hootenanny Packaging"
 
 # Install RPM repository and AWS CLI tools (via pip for latest version)
-RUN yum install -q -y createrepo epel-release groff rpm-sign && \
+RUN yum install -q -y createrepo epel-release groff less rpm-sign && \
     yum install -q -y python2-pip && \
     pip install -q --prefix /usr awscli
 
@@ -37,4 +37,4 @@ RUN echo "%_signature gpg" >> $RPMBUILD_HOME/.rpmmacros && \
     echo "%_gpg_name ${gpg_name}" >> $RPMBUILD_HOME/.rpmmacros && \
     echo "%_gpg_path ${RPMBUILD_HOME}/.gnupg" >> $RPMBUILD_HOME/.rpmmacros && \
     printf '%%__gpg_sign_cmd %%{__gpg} \\\n        gpg --force-v3-sigs --batch --no-verbose --no-armor --passphrase-fd 3 \\\n        %%{?_gpg_digest_algo:--digest-algo %%{_gpg_digest_algo}} \\\n        --no-secmem-warning \\\n        -u "%%{_gpg_name}" -sbo %%{__signature_filename} %%{__plaintext_filename}\n' >> $RPMBUILD_HOME/.rpmmacros && \
-    mkdir -p ${RPMBUILD_HOME}/{.aws,.gnupg,el7,RPMS}
+    mkdir -p ${RPMBUILD_HOME}/{.gnupg,el7,RPMS}

--- a/docker/Dockerfile.rpmbuild-repo
+++ b/docker/Dockerfile.rpmbuild-repo
@@ -6,6 +6,7 @@ LABEL \
   vendor="Radiant Solutions"
 
 ARG gpg_name="Hootenanny Packaging"
+ARG role_arn
 
 # Install RPM repository and AWS CLI tools (via pip for latest version)
 RUN yum install -q -y createrepo epel-release groff less rpm-sign && \
@@ -21,9 +22,13 @@ USER ${RPMBUILD_USER}
 WORKDIR ${RPMBUILD_HOME}
 
 # Create stub awscli configuration and enable the keepnewer plugin.
-RUN mkdir -p $RPMBUILD_HOME/.aws && \
-    printf "[default]\nregion=${AWS_DEFAULT_REGION:-us-east-1}\n\n" > $RPMBUILD_HOME/.aws/config && \
-    printf "[plugins]\nkeepnewer=keepnewer\n\n" >> $RPMBUILD_HOME/.aws/config
+RUN aws configure set plugins.keepnewer keepnewer && \
+    if [ ! -z "${role_arn}" ] ; then \
+       profile=$(basename ${role_arn}) && \
+       aws configure set credential_source Environment --profile ${profile} && \
+       aws configure set region ${AWS_DEFAULT_REGION:-us-east-1} --profile ${profile} && \
+       aws configure set role_arn ${role_arn} --profile ${profile}; \
+    fi
 
 # Add RPM signing macros to ~/.rpmmacros, specifying:
 #  * The signing digest algorithm (defaulting to sha256)

--- a/scripts/keepnewer.py
+++ b/scripts/keepnewer.py
@@ -22,24 +22,22 @@ class KeepNewerSync(SizeAndLastModifiedSync):
     ARGUMENT = KEEP_NEWER
 
     def determine_should_sync(self, src_file, dest_file):
-        src_time = src_file.last_update
-        dest_time = dest_file.last_update
-        delta = dest_time - src_time
-        cmd = src_file.operation_name
-
-        if cmd == 'download' and self.total_seconds(delta) > 0:
+        delta = self.total_seconds(
+            dest_file.last_update - src_file.last_update
+        )
+        if src_file.operation_name == 'download' and delta > 0:
             LOG.debug(
-                "KeepNewerSync.determine_should_sync: %s -> %s, total_seconds: %s",
-                src_file.src,
-                src_file.dest,
-                self.total_seconds(delta)
+                "not syncing: %s -> %s, destination newer by %ss",
+                src_file.src, src_file.dest, delta
             )
 
             # delta is positive, so the destination file is newer
             # what is s3, return False to keep it.
             return False
         else:
-            return super(KeepNewerSync, self).determine_should_sync(src_file, dest_file)
+            return super(KeepNewerSync, self).determine_should_sync(
+                src_file, dest_file
+            )
 
 
 def awscli_initialize(cli):

--- a/scripts/keepnewer.py
+++ b/scripts/keepnewer.py
@@ -1,0 +1,51 @@
+import logging
+
+from awscli.customizations.s3.syncstrategy.base import SizeAndLastModifiedSync
+
+
+LOG = logging.getLogger('awscli.customizations.s3.syncstrategy.keepnewer')
+
+
+KEEP_NEWER = {
+    'name': 'keep-newer',
+    'action': 'store_true',
+    'help_text': (
+        'When syncing from S3 to local, keep local items that have timestamps '
+        'newer than existing items in S3. The default behavior is to '
+        'overwrite newer files with the S3 version.'
+    )
+}
+
+
+class KeepNewerSync(SizeAndLastModifiedSync):
+
+    ARGUMENT = KEEP_NEWER
+
+    def determine_should_sync(self, src_file, dest_file):
+        src_time = src_file.last_update
+        dest_time = dest_file.last_update
+        delta = dest_time - src_time
+        cmd = src_file.operation_name
+
+        if cmd == 'download' and self.total_seconds(delta) > 0:
+            LOG.debug(
+                "KeepNewerSync.determine_should_sync: %s -> %s, total_seconds: %s",
+                src_file.src,
+                src_file.dest,
+                self.total_seconds(delta)
+            )
+
+            # delta is positive, so the destination file is newer
+            # what is s3, return False to keep it.
+            return False
+        else:
+            return super(KeepNewerSync, self).determine_should_sync(src_file, dest_file)
+
+
+def awscli_initialize(cli):
+    cli.register('building-command-table.sync', register_sync_strategies)
+
+
+def register_sync_strategies(command_table, session, **kwargs):
+    strategy = KeepNewerSync(sync_type='file_at_src_and_dest')
+    strategy.register_strategy(session)

--- a/scripts/repo-sync.sh
+++ b/scripts/repo-sync.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+set -euo pipefail

--- a/scripts/repo-sync.sh
+++ b/scripts/repo-sync.sh
@@ -1,2 +1,86 @@
 #!/bin/bash
 set -euo pipefail
+
+DEST=$(pwd)
+BUCKET=hoot-rpm
+PREFIX=develop
+
+set +u
+REGION=${AWS_DEFAULT_REGION:-us-east-1}
+set -u
+
+while getopts ":b:d:p:r:" opt; do
+    case "${opt}" in
+        b)
+            BUCKET="${OPTARG}"
+            ;;
+        d)
+            DEST="${OPTARG}"
+            ;;
+        p)
+            PREFIX="${OPTARG}"
+            ;;
+        r)
+            REGION="${OPTARG}"
+            ;;
+        *)
+            usage=yes
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+## Setting up.
+REPO=$DEST/$PREFIX
+
+S3_URL="s3://${BUCKET}/${PREFIX}"
+if [ "${REGION}" == "us-east-1" ]; then
+    S3_HOST=s3.amazonaws.com
+else
+    S3_HOST=s3-$REGION.amazonaws.com
+fi
+
+if [ ! -d $REPO ] ; then
+    mkdir -p $REPO
+fi
+
+# If the repo exists, grab it's last modified timestamp.
+REPO_TS=$(aws s3api head-object --bucket hoot-rpm --key $PREFIX/repodata/repomd.xml --query LastModified --region $REGION --output text 2>/dev/null || printf none)
+
+if [ "${REPO_TS}" == "none" ]; then
+    createrepo --database --unique-md-filenames --deltas $REPO
+else
+    mkdir -p $REPO/repodata
+
+    # The repo already exists, sync the repository data.
+    aws s3 sync $S3_URL/repodata $REPO/repodata --region $REGION
+
+    # TODO: Go through existing RPMs
+fi
+
+# Bail early before untested code.
+exit 0
+
+# Ensure a hoot.repo exists for use with yum-config-manager.
+if [ ! -d $REPO/hoot.repo]; then
+    echo "cat > $REPO/hoot.repo <<EOF"
+     cat > $REPO/hoot.repo <<EOF
+[hoot-develop]
+name = Hootenanny Development
+baseurl = https://${S3_HOST}/${BUCKET}/${PREFIX}
+enabled = 1
+gpgcheck = 0
+
+[hoot-deps]
+name = Hootenanny Dependencies
+baseurl = https://s3.amazonaws.com/hoot-repo/el7/deps/release
+enabled = 1
+gpgcheck = 1
+repo_gpgcheck = 1
+gpgkey = https://s3.amazonaws.com/hoot-repo/el7/hoot.gpg
+EOF
+fi
+
+
+# Prune old packages.
+aws s3 sync $REPO/ $S3_URL --delete --region $REGION

--- a/scripts/repo-sync.sh
+++ b/scripts/repo-sync.sh
@@ -3,25 +3,32 @@ set -euo pipefail
 
 # Default variables.
 DEST=$(pwd)
-BUCKET=hoot-rpm
-KEEP=5
-PREFIX=develop
+BUCKET=""
+KEEP=10
+PREFIX=""
+UPLOAD=yes
 USAGE=no
 
 # These variables default to value of AWS CLI environment
 # variables (if defined).
 set +u
-PROFILE=${AWS_PROFILE:-hoot-rpm-develop}
+PROFILE=${AWS_PROFILE:-default}
 REGION=${AWS_DEFAULT_REGION:-us-east-1}
 set -u
 
-while getopts ":a:b:d:k:p:r:" opt; do
+# Getting parameters from the command line.
+while getopts ":a:b:p:d:k:nr:" opt; do
     case "${opt}" in
-        a)
-            PROFILE="${OPTARG}"
-            ;;
+        # Required parameters.
         b)
             BUCKET="${OPTARG}"
+            ;;
+        p)
+            PREFIX="${OPTARG}"
+            ;;
+        # Optional parameters.
+        a)
+            PROFILE="${OPTARG}"
             ;;
         d)
             DEST="${OPTARG}"
@@ -29,8 +36,8 @@ while getopts ":a:b:d:k:p:r:" opt; do
         k)
             KEEP="${OPTARG}"
             ;;
-        p)
-            PREFIX="${OPTARG}"
+        n)
+            UPLOAD="no"
             ;;
         r)
             REGION="${OPTARG}"
@@ -42,14 +49,17 @@ while getopts ":a:b:d:k:p:r:" opt; do
 done
 shift $((OPTIND-1))
 
-# Abort if invalid options.
-if [ "${USAGE}" == "yes" ]; then
-    echo "repo_sync.sh: [-a <AWS Profile>] [-b <S3 Bucket>] [-d <Local Destination>] [-p <S3 Prefix>] [-r <AWS Region>]"
+# Setting up.
+function usage() {
+    echo "repo_sync.sh: -b <S3 Bucket> -p <S3 Prefix> [-a <AWS CLI Profile>] [-d <Local Destination>] [-k <Keep>] [-n No Upload] [-r <AWS Region>]"
     exit 1
+}
+
+# Abort if invalid options.
+if [[ "${USAGE}" == "yes" || -z "${BUCKET}" || -z "${PREFIX}" ]]; then
+    usage
 fi
 
-
-## Setting up.
 REPO=$DEST/$PREFIX
 S3_URL="s3://${BUCKET}/${PREFIX}"
 if [ "${REGION}" == "us-east-1" ]; then
@@ -67,11 +77,13 @@ REPO_TS=$(aws s3api head-object --bucket $BUCKET --key $PREFIX/repodata/repomd.x
 
 if [ "${REPO_TS}" == "none" ]; then
     # Initialize the yum repository, as it doesn't exist in S3.
-    createrepo --database --unique-md-filenames --deltas $REPO
+    if [ ! -f $REPO/repodata/repomd.xml ] ; then
+        createrepo --database --unique-md-filenames --deltas $REPO
+    fi
 
     # Ensure a hoot.repo exists for use with yum-config-manager.
-    echo "cat > $REPO/hoot.repo <<EOF"
-    cat > $REPO/hoot.repo <<EOF
+    if [ ! -f $REPO/hoot.repo ]; then
+        cat > $REPO/hoot.repo <<EOF
 [hoot-develop]
 name = Hootenanny Development
 baseurl = https://${S3_HOST}/${BUCKET}/${PREFIX}
@@ -86,17 +98,20 @@ gpgcheck = 1
 repo_gpgcheck = 1
 gpgkey = https://s3.amazonaws.com/hoot-repo/el7/hoot.gpg
 EOF
+    fi
 else
-    # The repo already exists, sync the repository data, but keep
-    # any newer files/rpms.
+    # The repo already exists, sync the repository files down, but
+    # keep local files that are more recent than what's in S3.
     aws s3 sync $S3_URL $REPO --profile $PROFILE --region $REGION --keep-newer
 fi
 
-# Only keep as many packages as specified.
+# Only keep as many packages as specified, deleting older versions.
 repomanage --keep $KEEP --old $REPO | xargs rm -f -v
 
 # Update the repository metadata.
 createrepo --update $REPO
 
-# Sync back to the mothership, deleting
-aws s3 sync $REPO $S3_URL --delete --profile $PROFILE --region $REGION
+if [ "${UPLOAD}" == "yes" ]; then
+    # Upload back to the S3 bucket, deleting any files not present locally.
+    aws s3 sync $REPO $S3_URL --delete --profile $PROFILE --region $REGION
+fi

--- a/shell/Vars.sh
+++ b/shell/Vars.sh
@@ -241,6 +241,38 @@ function run_dep_image() {
     fi
 }
 
+function run_repo_image() {
+    local OPTIND opt
+    local image=hootenanny/rpmbuild-repo
+    local usage=no
+
+    while getopts ":i:" opt; do
+        case "${opt}" in
+            i)
+                image="${OPTARG}"
+                ;;
+            *)
+                usage=yes
+                ;;
+        esac
+    done
+    shift $((OPTIND-1))
+
+    if [ "${usage}" = "yes" ]; then
+        echo "run_repo_image: [-i <image>]"
+    else
+        mkdir -p $RPMS
+        docker run \
+               -e AWS_PROFILE=${AWS_PROFILE:-default} \
+               -e AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id) \
+               -e AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key) \
+               -v $RPMS:/rpmbuild/RPMS:ro \
+               -v $SCRIPT_HOME/scripts:/rpmbuild/scripts:ro \
+               -it --rm \
+               $image "$@"
+    fi
+}
+
 # Runs a hootenanny build image.
 function run_hoot_build_image() {
     local OPTIND opt

--- a/shell/Vars.sh
+++ b/shell/Vars.sh
@@ -244,12 +244,16 @@ function run_dep_image() {
 function run_repo_image() {
     local OPTIND opt
     local image=hootenanny/rpmbuild-repo
+    local profile=default
     local usage=no
 
-    while getopts ":i:" opt; do
+    while getopts ":i:p:" opt; do
         case "${opt}" in
             i)
                 image="${OPTARG}"
+                ;;
+            p)
+                profile="${OPTARG}"
                 ;;
             *)
                 usage=yes
@@ -259,13 +263,14 @@ function run_repo_image() {
     shift $((OPTIND-1))
 
     if [ "${usage}" = "yes" ]; then
-        echo "run_repo_image: [-i <image>]"
+        echo "run_repo_image: [-i <image>] [-p <awscli profile>]"
     else
-        mkdir -p $RPMS
+        mkdir -p $RPMS $SCRIPT_HOME/el7
         docker run \
-               -e AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id) \
-               -e AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key) \
+               -e AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id --profile ${profile}) \
+               -e AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key --profile ${profile}) \
                -v $RPMS:/rpmbuild/RPMS:ro \
+               -v $SCRIPT_HOME/el7:/rpmbuild/el7:rw \
                -v $SCRIPT_HOME/scripts:/rpmbuild/scripts:ro \
                -it --rm \
                $image "$@"

--- a/shell/Vars.sh
+++ b/shell/Vars.sh
@@ -263,7 +263,6 @@ function run_repo_image() {
     else
         mkdir -p $RPMS
         docker run \
-               -e AWS_PROFILE=${AWS_PROFILE:-default} \
                -e AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id) \
                -e AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key) \
                -v $RPMS:/rpmbuild/RPMS:ro \


### PR DESCRIPTION
This PR adds the ability to synchronize with a `yum` repository in a remote S3 bucket with the `repo-sync.sh` script.

* Files that are newer locally are kept (e.g., so Jenkins rebuilds are actually updated) using the `keepnewer.py` Python module; it's an `awscli` plugin that adds the logic and CLI option for `aws s3 sync --keep-newer`.
* Modify `hootenanny/rpmbuild-repo` container to include latest `awscli` (installed via `pip`) and add optional `role_arn` argument that can be used for including a role-based `awscli` configuration profile in the container (with credentials passed via environment, and not kept in container).
* Minor tweaks to the `Makefile`, including adding the `latest-archive` convenience target to produce the latest Hootenanny archive.