### PR TITLE
Require Vagrant 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,9 @@ use [`config.yml`](./config.yml) as the source of truth for version information.
 This will build Hootenanny RPM from `develop`:
 
 ```
-make hoot-archive
-make hoot-rpm
+make archive
+make rpm
 ```
-
-Note: it's common for the `hoot-archive` target to fail the first time due to
-maven downloading outside dependencies.
 
 ## shell
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ use [`config.yml`](./config.yml) as the source of truth for version information.
     sudo apt-get -y install rpm
     ```
 * Docker
-* Vagrant
+* Vagrant 2.0+
 * `make`
 
 ## Quickstart

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,9 @@ require 'vagrant/ui'
 require 'vagrant/util/downloader'
 require 'vagrant/util/subprocess'
 
+# Require Vagrant 2.0+.
+Vagrant.require_version '>= 2.0.0'
+
 # Setting up globals from YAML configuration file.
 settings = YAML::load_file('config.yml')
 $images = settings.fetch('images', {})


### PR DESCRIPTION
Fixes #188.  Documents that Vagrant 2.0 is required and enforces it in the `Vagrantfile`.  Also update the `Makefile` targets and remove an outdated note from the `README`.