### PR TITLE
Don't run `UpdateAllCopyrightHeaders.sh` when creating the archive

### DIFF
--- a/scripts/hoot-archive.sh
+++ b/scripts/hoot-archive.sh
@@ -29,9 +29,6 @@ automake --add-missing --copy
 # Run configure, enable R&D, services, and PostgreSQL.
 ./configure --quiet --with-rnd --with-services --with-postgresql
 
-# Update the license headers.
-./scripts/copyright/UpdateAllCopyrightHeaders.sh
-
 # Make the archive.
 make -j$(nproc) clean
 make -j$(nproc) archive


### PR DESCRIPTION
As it says in the title, fixes #192.