### PR TITLE
Use Hootenanny Archive Script

### DIFF
--- a/scripts/hoot-archive.sh
+++ b/scripts/hoot-archive.sh
@@ -37,3 +37,5 @@ else
     make -j"$(nproc)" archive
     popd
 fi
+
+mv -v "$HOOT_REPO/hootenanny-[0-9]*.tar.gz" "$HOME/SOURCES"

--- a/scripts/hoot-archive.sh
+++ b/scripts/hoot-archive.sh
@@ -2,37 +2,38 @@
 set -euo pipefail
 HOOT_REPO="${HOOT_REPO:-${HOME}/hootenanny}"
 
-if [ ! -d $HOOT_REPO/.git ]; then
+if [ ! -d "$HOOT_REPO/.git" ]; then
     echo 'Please checkout Hootenanny repository first.'
     exit 1
 fi
 
-pushd $HOOT_REPO
-cp LocalConfig.pri.orig LocalConfig.pri
+ARCHIVE_SCRIPT="$HOOT_REPO/scripts/ci/archive.sh"
+if [ -x "$ARCHIVE_SCRIPT" ]; then
+    $ARCHIVE_SCRIPT
+else
+    # This revision of Hootenanny doesn't have the archive script, so generate
+    # one manually.
+    pushd "$HOOT_REPO"
+    cp LocalConfig.pri.orig LocalConfig.pri
 
-# TODO: Do we add `ccache` like in original `BuildArchive.sh`?
-#echo "QMAKE_CXX=ccache g++" >> LocalConfig.pri
+    # Temporarily allow undefined variables to allow us to source `SetupEnv.sh`.
+    set +u
+    source SetupEnv.sh
+    set -u
 
-# Temporarily allow undefined variables to allow us to source `SetupEnv.sh`.
-set +u
-source SetupEnv.sh
-set -u
+    source conf/database/DatabaseConfig.sh
 
-source conf/database/DatabaseConfig.sh
+    # Generate configure script.
+    aclocal
+    autoconf
+    autoheader
+    automake --add-missing --copy
 
-# Generate configure script.
-aclocal
-autoconf
-autoheader
-automake --add-missing --copy
+    # Run configure, enable R&D, services, and PostgreSQL.
+    ./configure --quiet --with-rnd --with-services --with-postgresql
 
-# Run configure, enable R&D, services, and PostgreSQL.
-./configure --quiet --with-rnd --with-services --with-postgresql
-
-# Make the archive.
-make -j$(nproc) clean
-make -j$(nproc) archive
-
-# Copy in source archive to RPM sources.
-cp -v hootenanny-[0-9]*.tar.gz $HOME/SOURCES
-popd
+    # Make the archive.
+    make -j"$(nproc)" clean
+    make -j"$(nproc)" archive
+    popd
+fi

--- a/scripts/hoot-archive.sh
+++ b/scripts/hoot-archive.sh
@@ -38,4 +38,4 @@ else
     popd
 fi
 
-mv -v "$HOOT_REPO/hootenanny-[0-9]*.tar.gz" "$HOME/SOURCES"
+mv -v "$HOOT_REPO"/hootenanny-[0-9]&.tar.gz "$HOME/SOURCES"

--- a/scripts/hoot-archive.sh
+++ b/scripts/hoot-archive.sh
@@ -38,4 +38,4 @@ else
     popd
 fi
 
-mv -v "$HOOT_REPO"/hootenanny-[0-9]&.tar.gz "$HOME/SOURCES"
+mv -v "$HOOT_REPO"/hootenanny-[0-9]*.tar.gz "$HOME/SOURCES"


### PR DESCRIPTION
Fixes #195.  This adapts to the `hoot-archive.sh` script to use the canonical archiving script from the Hootenanny repository from ngageoint/hootenanny#2393.  If the Hootenanny revision doesn't have the script, it falls back to its old behavior (to be removed when no longer necessary).