### PR TITLE
rpmbuild-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,10 @@ rpmbuild-base: \
 	rpmbuild \
 	.vagrant/machines/rpmbuild-base/docker/id
 
+rpmbuild-check: \
+	rpmbuild \
+	.vagrant/machines/rpmbuild-check/docker/id
+
 rpmbuild-generic: \
 	rpmbuild-base \
 	.vagrant/machines/rpmbuild-generic/docker/id

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,8 @@ DEPENDENCY_CONTAINERS := \
 	rpmbuild-postgis \
 	rpmbuild-nodejs
 
-REPO_CONTAINERS := \
+OTHER_CONTAINERS := \
+	rpmbuild-lint \
 	rpmbuild-repo
 
 DEPENDENCY_RPMS := \
@@ -167,7 +168,7 @@ GIT_COMMIT ?= develop
 	$(BUILD_CONTAINERS) \
 	$(DEPENDENCY_CONTAINERS) \
 	$(DEPENDENCY_RPMS) \
-	$(REPO_CONTAINERS) \
+	$(OTHER_CONTAINERS) \
 	$(RUN_CONTAINERS)
 
 all: $(BUILD_CONTAINERS)
@@ -207,9 +208,9 @@ rpmbuild-base: \
 	rpmbuild \
 	.vagrant/machines/rpmbuild-base/docker/id
 
-rpmbuild-check: \
+rpmbuild-lint: \
 	rpmbuild \
-	.vagrant/machines/rpmbuild-check/docker/id
+	.vagrant/machines/rpmbuild-lint/docker/id
 
 rpmbuild-generic: \
 	rpmbuild-base \

--- a/config.yml
+++ b/config.yml
@@ -44,6 +44,7 @@ images:
         buildrequires: true
         rpmbuild: true
         spec_file: 'SPECS/hootenanny.spec'
+    - rpmbuild-check: {}
     - rpmbuild-repo: {}
     - rpmbuild-geos:
         buildrequires: true

--- a/config.yml
+++ b/config.yml
@@ -44,7 +44,7 @@ images:
         buildrequires: true
         rpmbuild: true
         spec_file: 'SPECS/hootenanny.spec'
-    - rpmbuild-check: {}
+    - rpmbuild-lint: {}
     - rpmbuild-repo: {}
     - rpmbuild-geos:
         buildrequires: true

--- a/docker/Dockerfile.rpmbuild-check
+++ b/docker/Dockerfile.rpmbuild-check
@@ -1,0 +1,16 @@
+FROM hootenanny/rpmbuild:latest
+LABEL \
+  description="Container for checking Hootenanny RPMS Source Code" \
+  maintainer="justin.bronn@radiantsolutions.com" \
+  name="Hootenanny RPMS Check Image" \
+  vendor="Radiant Solutions"
+
+# Install EPEL, ShellCheck, and yamllint.
+RUN yum -q -y update && \
+    yum -q -y install epel-release && \
+    yum -q -y install yamllint ShellCheck && \
+    yum -q -y clean all
+
+# Use unprivleged RPM build user and work directory by default.
+USER ${RPMBUILD_USER}
+WORKDIR ${RPMBUILD_HOME}

--- a/docker/Dockerfile.rpmbuild-lint
+++ b/docker/Dockerfile.rpmbuild-lint
@@ -1,8 +1,8 @@
 FROM hootenanny/rpmbuild:latest
 LABEL \
-  description="Container for checking Hootenanny RPMS Source Code" \
+  description="Container for linting Hootenanny RPMS Source Code" \
   maintainer="justin.bronn@radiantsolutions.com" \
-  name="Hootenanny RPMS Check Image" \
+  name="Hootenanny RPMS Lint Image" \
   vendor="Radiant Solutions"
 
 # Install EPEL, ShellCheck, and yamllint.

--- a/shell/Vars.sh
+++ b/shell/Vars.sh
@@ -175,6 +175,13 @@ function build_base_images() {
            $SCRIPT_HOME
 }
 
+function build_check_images() {
+    docker build \
+           -f $SCRIPT_HOME/docker/Dockerfile.rpmbuild-check \
+           -t hootenanny/rpmbuild-check \
+           $SCRIPT_HOME
+}
+
 # Build images for creating and signing the RPM repository.
 function build_repo_images() {
     docker build \

--- a/shell/Vars.sh
+++ b/shell/Vars.sh
@@ -175,18 +175,17 @@ function build_base_images() {
            $SCRIPT_HOME
 }
 
-function build_check_images() {
-    docker build \
-           -f $SCRIPT_HOME/docker/Dockerfile.rpmbuild-lint \
-           -t hootenanny/rpmbuild-lint \
-           $SCRIPT_HOME
-}
-
-# Build images for creating and signing the RPM repository.
-function build_repo_images() {
+function build_other_images() {
+    # Build image for creating and signing the RPM repository.
     docker build \
            -f $SCRIPT_HOME/docker/Dockerfile.rpmbuild-repo \
            -t hootenanny/rpmbuild-repo \
+           $SCRIPT_HOME
+
+    # Build image for linting this repository's source code.
+    docker build \
+           -f $SCRIPT_HOME/docker/Dockerfile.rpmbuild-lint \
+           -t hootenanny/rpmbuild-lint \
            $SCRIPT_HOME
 }
 

--- a/shell/Vars.sh
+++ b/shell/Vars.sh
@@ -177,8 +177,8 @@ function build_base_images() {
 
 function build_check_images() {
     docker build \
-           -f $SCRIPT_HOME/docker/Dockerfile.rpmbuild-check \
-           -t hootenanny/rpmbuild-check \
+           -f $SCRIPT_HOME/docker/Dockerfile.rpmbuild-lint \
+           -t hootenanny/rpmbuild-lint \
            $SCRIPT_HOME
 }
 


### PR DESCRIPTION
This adds the `rpmbuild-lint` container that has `yamllint` and `shellcheck` installed.