### PR TITLE
Retrieve RPMBUILD_DIST from configuration file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ RPMBUILD_DIST := .el7
 
 # All versions use a YAML reference so they only have to be defined once,
 # just grep for this reference and print it out.
-config_version = $(shell cat config.yml | grep '\&$(1)_version' | awk '{ print $$3 }' | tr -d "'")
+config_reference = $(shell cat config.yml | grep '\&$(1)' | awk '{ print $$3 }' | tr -d "'")
+config_version = $(call config_reference,$(1)_version)
 
 # Where Vagrant puts the Docker container id after it's been created.
 container_id = .vagrant/machines/$(1)/docker/id

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,6 @@
 DOCKER ?= docker
 VAGRANT ?= vagrant
 
-# TODO: This needs to be retrieved from a setting in config.yml.
-RPMBUILD_DIST := .el7
-
-
 ## Macro functions.
 
 # All versions use a YAML reference so they only have to be defined once,
@@ -46,6 +42,7 @@ latest_hoot_archive = $(call latest_file,SOURCES,hootenanny-[0-9]\*.tar.gz)
 latest_hoot_version_gen = $(subst SOURCES/hootenanny-,,$(subst .tar.gz,,$(call latest_hoot_archive)))
 
 # Variants for getting RPM file names.
+RPMBUILD_DIST := $(call config_reference,rpmbuild_dist)
 rpm_file = RPMS/$(2)/$(1)-$(call config_version,$(1))$(RPMBUILD_DIST).$(2).rpm
 rpm_file2 = RPMS/$(3)/$(1)-$(call config_version,$(2))$(RPMBUILD_DIST).$(3).rpm
 

--- a/config.yml
+++ b/config.yml
@@ -24,12 +24,17 @@ maven:
   cache_sha1: &maven_cache_sha1 'efbd6edd5a13bf3806780f144b4fe314c34eccfc'
 
 
+rpmbuild:
+  dist: &rpmbuild_dist '.el7'
+  uid: &rpmbuild_uid 1000
+
+
 images:
   base: !!omap
     - rpmbuild:
         args:
-          rpmbuild_dist: .el7
-          rpmbuild_uid: 1000
+          rpmbuild_dist: *rpmbuild_dist
+          rpmbuild_uid: *rpmbuild_uid
     - rpmbuild-base: {}
     - rpmbuild-generic: {}
     - rpmbuild-pgdg:

--- a/shell/Vars.sh
+++ b/shell/Vars.sh
@@ -66,7 +66,7 @@ PG_VERSION=$( config_version pg )
 PG_DOTLESS=$(echo $PG_VERSION | tr -d '.')
 
 ## Package versioning variables.
-RPMBUILD_DIST=.el7
+RPMBUILD_DIST=$( config_version rpmbuild_dist )
 
 # Where binary RPMs are placed.
 RPM_X86_64=$RPMS/x86_64


### PR DESCRIPTION
Fixes a longstanding TODO: the distribution ("dist") part of the package string should come from the value in `config.yml` rather than being hardcoded.