### PR TITLE
Forcing git clone to use https instead of ssh

### DIFF
--- a/docker/Dockerfile.rpmbuild-hoot-release
+++ b/docker/Dockerfile.rpmbuild-hoot-release
@@ -17,6 +17,9 @@ ARG pg_data=/var/lib/pgsql/${pg_version}/data
 # Have PostgreSQL data directory persist in environment variable.
 ENV PGDATA=${pg_data}
 
+# Force clone to use https vs ssh
+RUN git config --global url."https://".insteadOf git://
+
 # Switch back to root.
 USER root
 


### PR DESCRIPTION
When we are forced to build in an environment with a poorly configured web filtering system, https protocol ensures that we can `git clone`.