### PR TITLE
Match UID for rpmbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This repository houses the RPM building specifications for Hootenanny and its
 third-party dependencies.
 
 RPMs are built in minimal, ephemeral CentOS 7 Docker containers.  Invoking programs
-use [`config.yml`](./config.yml) as the source of truth for version information.
+use [`config.yml`](./doc/config.md) as the source of truth for version information.
+
 
 ## Requirements
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,12 @@ $rpms = settings.fetch('rpms', {})
 $pg_version = settings.fetch('versions')['postgresql']
 $pg_dotless = $pg_version.gsub('.', '')
 
+# Special workaround if we want the `rpmbuild` UID to match that of
+# the user invoking Vagrant, which simplifies file permissions for
+# host volume mounts.
+if ENV.key?['RPMBUILD_UID_MATCH']
+  $images['base']['rpmbuild']['args']['rpmbuild_uid'] = Process.uid
+end
 
 ## Functions used by Vagrant containers.
 
@@ -119,13 +125,6 @@ def build_container(config, name, options)
       # Start build arguments.
       build_args = []
       args = options.fetch('args', {})
-
-      # Special workaround if we want the `rpmbuild` UID to match that of
-      # the user invoking Vagrant, which simplifies file permissions for
-      # host volume mounts.
-      if name == 'rpmbuild' and ENV['RPMBUILD_UID_MATCH']
-        args['rpmbuild_uid'] = Process.uid
-      end
 
       # Pull out `BuildRequires:` packages and add them to a `packages`
       # build argument for the container.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -120,6 +120,13 @@ def build_container(config, name, options)
       build_args = []
       args = options.fetch('args', {})
 
+      # Special workaround if we want the `rpmbuild` UID to match that of
+      # the user invoking Vagrant, which simplifies file permissions for
+      # host volume mounts.
+      if name == 'rpmbuild' and ENV['RPMBUILD_UID_MATCH']
+        args['rpmbuild_uid'] = Process.uid
+      end
+
       # Pull out `BuildRequires:` packages and add them to a `packages`
       # build argument for the container.
       if options.fetch('buildrequires', false)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ $pg_dotless = $pg_version.gsub('.', '')
 # Special workaround if we want the `rpmbuild` UID to match that of
 # the user invoking Vagrant, which simplifies file permissions for
 # host volume mounts.
-if ENV.key?['RPMBUILD_UID_MATCH']
+if ENV.key?('RPMBUILD_UID_MATCH')
   $images['base']['rpmbuild']['args']['rpmbuild_uid'] = Process.uid
 end
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -1,0 +1,41 @@
+# Configuration Reference
+
+The repository's primary configuration comes from `config.yaml`.  In addition, environment variables may be used to modify some behavior.
+
+## `config.yml`
+
+This YAML file holds the all the relevant settings for this repository in dictionaries:
+
+* `versions`: Versions of the dependency RPMs
+* `images`: Build arguments, tags, and other settings for container images
+* `maven`: Maven cache URL and SHA1 checksum
+
+Because this file is also used by [shell](../shell), any relevant variable should have an anchor property (`&`).  This allows a shell script to easily search for a value without using a YAML library.  For example:
+
+```yaml
+versions:
+  geos: &geos_version: '3.6.2-1'
+```
+
+In addition, using anchors allows reuse of the variable without repeating it, for example:
+
+```yaml
+images:
+  - rpmbuild-gdal:
+      args:
+        geos_version: *geos_version
+```
+
+## Environment Variables
+
+### `MAVEN_CACHE`
+
+Hootenanny uses Maven for building its Java services code, which requires retrieving assets over HTTP.  To prevent frequent timeouts and race conditions a pre-existing cache is downloaded prior to trying to run the `rpmbuild-hoot-release` or `rpmbuild-hoot-devel` containers.   Setting the `MAVEN_CACHE` environment variable to any value other than `1` disables retrieving this cache file.  Example:
+
+```
+MAVEN_CACHE=0 vagrant status
+```
+
+### `RPMBUILD_UID_MATCH`
+
+By default, the containers use a UID of 1000 for the non-privileged `rpmbuild` user.  While this is the first-user ID on most Linux distributions, this is not universally true -- and will result in permission errors because the host's UID doesn't match that of the container because [Docker bind mounts](https://docs.docker.com/storage/bind-mounts/) are used .  Thus, if you want the `rpmbuild` container user to match that of the host user invoking `docker`, set the `RPMBUILD_UID_MATCH` environment variable to any value.

--- a/doc/config.md
+++ b/doc/config.md
@@ -10,7 +10,7 @@ This YAML file holds the all the relevant settings for this repository in dictio
 * `images`: Build arguments, tags, and other settings for container images
 * `maven`: Maven cache URL and SHA1 checksum
 
-Because this file is also used by [shell](../shell), any relevant variable should have an anchor property (`&`).  This allows a shell script to easily search for a value without using a YAML library.  For example:
+Because this file is also used by [shell](../shell) build method (in addition to Vagrant), any relevant variable should have an anchor property (`&`).  This allows a shell script to easily search for a value without using a YAML library.  For example:
 
 ```yaml
 versions:


### PR DESCRIPTION
This PR will use the same UID of invoking user for `rpmbuild` in containers if the `RPMBUILD_UID_MATCH` environment variable is set.  In addition, configuration documentation was added for the environment variable, `MAVEN_CACHE` (#178), and `config.yml`.