### PR TITLE
rpmbuild gid build argument

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,11 +15,12 @@ $rpms = settings.fetch('rpms', {})
 $pg_version = settings.fetch('versions')['postgresql']
 $pg_dotless = $pg_version.gsub('.', '')
 
-# Special workaround if we want the `rpmbuild` UID to match that of
-# the user invoking Vagrant, which simplifies file permissions for
-# host volume mounts.
+# Special workaround if we want the `rpmbuild` UID and GID to match that of
+# the user invoking Vagrant, which simplifies file permissions for host
+# volume mounts.
 if ENV.key?('RPMBUILD_UID_MATCH')
   $images['base']['rpmbuild']['args']['rpmbuild_uid'] = Process.uid
+  $images['base']['rpmbuild']['args']['rpmbuild_gid'] = Process.gid
 end
 
 ## Functions used by Vagrant containers.

--- a/config.yml
+++ b/config.yml
@@ -35,6 +35,7 @@ images:
         args:
           rpmbuild_dist: *rpmbuild_dist
           rpmbuild_uid: *rpmbuild_uid
+          rpmbuild_gid: *rpmbuild_uid
     - rpmbuild-base: {}
     - rpmbuild-generic: {}
     - rpmbuild-pgdg:

--- a/docker/Dockerfile.rpmbuild
+++ b/docker/Dockerfile.rpmbuild
@@ -15,6 +15,7 @@ ARG lang=en_US.UTF-8
 ARG locale=en_US.UTF-8
 ARG rpmbuild_dist=.el7
 ARG rpmbuild_uid=1000
+ARG rpmbuild_gid=${rpmbuild_uid}
 ARG rpmbuild_user=rpmbuild
 ARG rpmbuild_home=/${rpmbuild_user}
 
@@ -27,7 +28,8 @@ ENV LANG=${lang} \
     RPMBUILD_HOME=${rpmbuild_home}
 
 # Create unprivileged user for building RPMs, and setup basic macros.
-RUN useradd -d ${rpmbuild_home} -m -s /bin/bash -u ${rpmbuild_uid} ${rpmbuild_user} && \
+RUN groupadd -g ${rpmbuild_gid} ${rpmbuild_user} && \
+    useradd -d ${rpmbuild_home} -m -s /bin/bash -u ${rpmbuild_uid} -g ${rpmbuild_gid} ${rpmbuild_user} && \
     echo "%_hardened_build ${hardened_build}" >> ${rpmbuild_home}/.rpmmacros && \
     echo "%_smp_mflags -j%(nproc) -l%(expr %(nproc) + 2)" >> ${rpmbuild_home}/.rpmmacros && \
     echo "%_topdir ${rpmbuild_home}" >> ${rpmbuild_home}/.rpmmacros && \

--- a/shell/Vars.sh
+++ b/shell/Vars.sh
@@ -150,6 +150,7 @@ function build_base_images() {
     docker build \
            --build-arg rpmbuild_dist=$RPMBUILD_DIST \
            --build-arg rpmbuild_uid=$(id -u) \
+           --build-arg rpmbuild_gid=$(id -g) \
            -f $SCRIPT_HOME/docker/Dockerfile.rpmbuild \
            -t hootenanny/rpmbuild \
            $SCRIPT_HOME


### PR DESCRIPTION
Correct branch destination now.

By default, `useradd` gives the new user a primary group with a GID matching the UID; customization of the GID is not supported.  This PR enables customization of the GID, this is necessary to support CircleCI's build user (`circleci`), whose values don't match.  Due to [bind mounts](https://docs.docker.com/storage/bind-mounts/), both must match the invoking user or else there will be file permission issues writing RPMs.