### PR TITLE
Develop Repository Pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ workflows:
             - develop-rpm
     triggers:
       - schedule:
-          cron: "40 16 * * *"
+          cron: "12 17 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,7 @@ jobs:
       - run:
           name: 'Install RPM Tools'
           command: |
-            sudo apt-get update -qq
-            sudo apt-get install -qq -y rpm awscli
+            sudo ./scripts/rpm-install.sh
       - run:
           name: 'Install Vagrant'
           command: |
@@ -50,6 +49,10 @@ jobs:
       - checkout
       - attach_workspace:
           at: images
+      - run:
+          name: 'Install RPM Tools'
+          command: |
+            sudo ./scripts/rpm-install.sh
       - run:
           name: 'Load rpmbuild-hoot-release image'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,6 @@ jobs:
           name: 'Install RPM Tools'
           command: |
             sudo ./scripts/rpm-install.sh
-            sudo apt-get -qq -y install awscli
       - run:
           name: 'Load rpmbuild-hoot-release image'
           command: |
@@ -63,7 +62,7 @@ jobs:
           command: |
             mkdir -p el7/develop
             LATEST_ARCHIVE="$(./scripts/latest-archive.sh -b hoot-archives -p circle/develop)"
-            if [ "$(./scripts/query-archive.sh -a $LATEST_ARCHIVE -b hoot-repo -p el7/develop)" = "0" ]; then
+            if [ "$(./scripts/query-archive.sh -a $LATEST_ARCHIVE -b hoot-repo -p el7/develop/)" = "0" ]; then
                 aws s3 cp s3://hoot-archives/$LATEST_PREFIX SOURCES/
                 make rpm
                 mv -v RPMS/{noarch,x86_64}/*.rpm el7/develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,9 +45,10 @@ jobs:
       - run:
           name: 'Compile Latest Develop RPM'
           command: |
+            set -x
             mkdir -p cache/m2 cache/npm el7/develop RPMS
             LATEST_ARCHIVE="$(./scripts/latest-archive.sh -b hoot-archives -p circle/develop)"
-            if [ "$(./scripts/query-archive.sh -a $LATEST_ARCHIVE -b hoot-repo -p el7/develop/)" = "0" ]; then
+            if [ "$(./scripts/query-archive.sh -a $LATEST_ARCHIVE -b hoot-repo -p el7/develop)" = "0" ]; then
                 aws s3 cp s3://hoot-archives/$LATEST_ARCHIVE SOURCES/
                 source shell/Vars.sh
                 maven_cache
@@ -91,7 +92,7 @@ workflows:
             - develop-rpm
     triggers:
       - schedule:
-          cron: "30 16 * * *"
+          cron: "40 16 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
             if [ -f el7/develop/none.rpm ]; then
                 echo "RPM has already been created."
             else
-                ./scripts/repo-sync -b hoot-repo -p el7/develop
+                ./scripts/repo-sync.sh -b hoot-repo -p el7/develop
             fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,10 @@ jobs:
           command: |
             LATEST_PREFIX="$(./scripts/latest-archive.sh -b hoot-archives -p circle/develop)"
             aws s3 cp s3://hoot-archives/$LATEST_PREFIX SOURCES/
+      - run:
+          name: 'Make Hootenanny RPM from Archive'
+          command: |
+            make rpm
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,6 @@ jobs:
       - run:
           name: 'Compile Latest Develop RPM'
           command: |
-            set -x
             mkdir -p cache/m2 cache/npm el7/develop RPMS
             LATEST_ARCHIVE="$(./scripts/latest-archive.sh -b hoot-archives -p circle/develop)"
             if [ "$(./scripts/query-archive.sh -a $LATEST_ARCHIVE -b hoot-repo -p el7/develop/)" = "0" ]; then
@@ -79,7 +78,7 @@ jobs:
             if [ -f el7/develop/none.rpm ]; then
                 echo "RPM has already been created."
             else
-                ./scripts/repo-sync.sh -b hoot-repo -p el7/develop
+                ./scripts/repo-sync.sh -a "" -b hoot-repo -p el7/develop
             fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             if [ -f el7/develop/none.rpm ]; then
                 echo "RPM has already been created."
             else
-                ./scripts/repo-sync.sh -a "" -b hoot-repo -p el7/develop
+                ./scripts/repo-sync.sh -a "" -b hoot-repo -p el7/develop -q
             fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
             mkdir -p el7/develop
             LATEST_ARCHIVE="$(./scripts/latest-archive.sh -b hoot-archives -p circle/develop)"
             if [ "$(./scripts/query-archive.sh -a $LATEST_ARCHIVE -b hoot-repo -p el7/develop/)" = "0" ]; then
-                aws s3 cp s3://hoot-archives/$LATEST_PREFIX SOURCES/
+                aws s3 cp s3://hoot-archives/$LATEST_ARCHIVE SOURCES/
                 make rpm
                 mv -v RPMS/{noarch,x86_64}/*.rpm el7/develop
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ workflows:
   tests:
     jobs:
       - lint
-      - rpmbuild-hoot-release:
+      - rpmbuild-hoot-release
       - develop-rpm:
           requires:
             - rpmbuild-hoot-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,15 +37,32 @@ jobs:
           command: |
             export RPMBUILD_UID_MATCH=1
             make rpmbuild-hoot-release
+            mkdir -p images
+            docker save hootenanny/rpmbuild-hoot-release:latest -o images/rpmbuild-hoot-release.tar
+      - persist_to_workspace:
+          root: images
+          paths:
+            - rpmbuild-hoot-release.tar
+  develop-update:
+    machine:
+      enabled: true
+    steps:
+      - checkout
+      - attach_workspace:
+          at: images
+      - run:
+          name: 'Load rpmbuild-hoot-release image'
+          command: |
+            docker load --input images/rpmbuild-hoot-release.tar
       - run:
           name: 'Retrieve Latest Develop Archive'
           command: |
             LATEST_PREFIX="$(./scripts/latest-archive.sh -b hoot-archives -p circle/develop)"
             aws s3 cp s3://hoot-archives/$LATEST_PREFIX SOURCES/
-      - run:
-          name: 'Make Hootenanny RPM from Archive'
-          command: |
-            make rpm
+      # - run:
+      #     name: 'Make Hootenanny RPM from Archive'
+      #     command: |
+      #       make rpm
 
 workflows:
   version: 2
@@ -55,3 +72,6 @@ workflows:
       - rpmbuild-hoot-release:
           requires:
             - lint
+      - develop-update:
+          requires:
+            - rpmbuild-hoot-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,6 @@ jobs:
       - run:
           name: 'Compile Latest Develop RPM'
           command: |
-            set -x
             mkdir -p cache/m2 cache/npm el7/develop RPMS
             LATEST_ARCHIVE="$(./scripts/latest-archive.sh -b hoot-archives -p circle/develop)"
             if [ "$(./scripts/query-archive.sh -a $LATEST_ARCHIVE -b hoot-repo -p el7/develop)" = "0" ]; then
@@ -75,7 +74,6 @@ jobs:
       - run:
           name: 'Update and Sync Develop Repository'
           command: |
-            set -x
             if [ -f el7/develop/none.rpm ]; then
                 echo "RPM has already been created."
             else
@@ -92,11 +90,11 @@ workflows:
             - develop-rpm
     triggers:
       - schedule:
-          cron: "12 17 * * *"
+          cron: "0 12,20 * * *"
           filters:
             branches:
               only:
-                - archive-rpm-pipeline
+                - develop
   tests:
     jobs:
       - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,23 +74,23 @@ jobs:
       - persist_to_workspace:
           root: el7/develop
           paths:
-            - *.rpm
-   develop-sync:
-     working_directory: '/rpmbuild/hootenanny-rpms'
-     docker:
-       - image: hootenanny/rpmbuild-repo@sha256:7147b62b7a6dded4b72003df0aca52ab4b667dba4da5c11a7ceb4b00bbacd120
-         user: rpmbuild
-     steps:
-       - attach_workspace:
-           at: el7/develop
-       - run:
-           name: 'Update and Sync Develop Repository'
-           command: |
-             if [ -f el7/develop/none.rpm ]; then
-                 echo "RPM has already been created."
-             else
-                 ./scripts/repo-sync -b hoot-repo -p el7/develop
-             fi
+            - "*.rpm"
+  develop-sync:
+    working_directory: '/rpmbuild/hootenanny-rpms'
+    docker:
+      - image: hootenanny/rpmbuild-repo@sha256:7147b62b7a6dded4b72003df0aca52ab4b667dba4da5c11a7ceb4b00bbacd120
+        user: rpmbuild
+    steps:
+      - attach_workspace:
+          at: el7/develop
+      - run:
+          name: 'Update and Sync Develop Repository'
+          command: |
+            if [ -f el7/develop/none.rpm ]; then
+                echo "RPM has already been created."
+            else
+                ./scripts/repo-sync -b hoot-repo -p el7/develop
+            fi
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,27 +33,15 @@ jobs:
           command: |
             export RPMBUILD_UID_MATCH=1
             make rpmbuild-hoot-release
-            mkdir -p images
-            docker save hootenanny/rpmbuild-hoot-release:latest -o images/rpmbuild-hoot-release.tar
-      - persist_to_workspace:
-          root: images
-          paths:
-            - rpmbuild-hoot-release.tar
   develop-rpm:
     machine:
       enabled: true
     steps:
       - checkout
-      - attach_workspace:
-          at: images
       - run:
-          name: 'Install RPM Tools and Vagrant'
+          name: 'Install RPM Tools'
           command: |
             ./scripts/rpm-install.sh
-      - run:
-          name: 'Load rpmbuild-hoot-release image'
-          command: |
-            docker load --input images/rpmbuild-hoot-release.tar
       - run:
           name: 'Compile Latest Develop RPM'
           command: |
@@ -62,8 +50,10 @@ jobs:
             LATEST_ARCHIVE="$(./scripts/latest-archive.sh -b hoot-archives -p circle/develop)"
             if [ "$(./scripts/query-archive.sh -a $LATEST_ARCHIVE -b hoot-repo -p el7/develop/)" = "0" ]; then
                 aws s3 cp s3://hoot-archives/$LATEST_ARCHIVE SOURCES/
+                mkdir -p RPMS
+                sudo chown -R 1000:1000 RPMS SOURCES
                 ./shell/BuildHoot.sh
-                mv -v RPMS/{noarch,x86_64}/*.rpm el7/develop
+                sudo mv -v RPMS/{noarch,x86_64}/*.rpm el7/develop
             else
                 touch el7/develop/none.rpm
             fi
@@ -92,13 +82,13 @@ jobs:
 
 workflows:
   version: 2
+  develop-repo:
+    jobs:
+      - develop-rpm
+      - develop-sync:
+          requires:
+            - develop-rpm
   tests:
     jobs:
       - lint
       - rpmbuild-hoot-release
-      - develop-rpm:
-          requires:
-            - rpmbuild-hoot-release
-      - develop-sync:
-          requires:
-            - develop-rpm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,12 +46,13 @@ jobs:
           name: 'Compile Latest Develop RPM'
           command: |
             set -x
-            mkdir -p el7/develop
+            mkdir -p cache/m2 cache/npm el7/develop RPMS
             LATEST_ARCHIVE="$(./scripts/latest-archive.sh -b hoot-archives -p circle/develop)"
             if [ "$(./scripts/query-archive.sh -a $LATEST_ARCHIVE -b hoot-repo -p el7/develop/)" = "0" ]; then
                 aws s3 cp s3://hoot-archives/$LATEST_ARCHIVE SOURCES/
-                mkdir -p RPMS
-                sudo chown -R 1000:1000 RPMS SOURCES
+                source shell/Vars.sh
+                maven_cache
+                sudo chown -R 1000:1000 cache RPMS SOURCES
                 ./shell/BuildHoot.sh
                 sudo mv -v RPMS/{noarch,x86_64}/*.rpm el7/develop
             else
@@ -68,6 +69,7 @@ jobs:
       - image: hootenanny/rpmbuild-repo@sha256:7147b62b7a6dded4b72003df0aca52ab4b667dba4da5c11a7ceb4b00bbacd120
         user: rpmbuild
     steps:
+      - checkout
       - attach_workspace:
           at: el7/develop
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,6 @@ jobs:
           name: 'Install RPM Tools and Vagrant'
           command: |
             ./scripts/rpm-install.sh
-            ./scripts/vagrant-install.sh
       - run:
           name: 'Load rpmbuild-hoot-release image'
           command: |
@@ -63,7 +62,7 @@ jobs:
             LATEST_ARCHIVE="$(./scripts/latest-archive.sh -b hoot-archives -p circle/develop)"
             if [ "$(./scripts/query-archive.sh -a $LATEST_ARCHIVE -b hoot-repo -p el7/develop/)" = "0" ]; then
                 aws s3 cp s3://hoot-archives/$LATEST_ARCHIVE SOURCES/
-                make rpm
+                ./shell/BuildHoot.sh
                 mv -v RPMS/{noarch,x86_64}/*.rpm el7/develop
             else
                 touch el7/develop/none.rpm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
       - run:
           name: 'Compile Latest Develop RPM'
           command: |
+            set -x
             mkdir -p el7/develop
             LATEST_ARCHIVE="$(./scripts/latest-archive.sh -b hoot-archives -p circle/develop)"
             if [ "$(./scripts/query-archive.sh -a $LATEST_ARCHIVE -b hoot-repo -p el7/develop/)" = "0" ]; then
@@ -85,6 +86,7 @@ jobs:
       - run:
           name: 'Update and Sync Develop Repository'
           command: |
+            set -x
             if [ -f el7/develop/none.rpm ]; then
                 echo "RPM has already been created."
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           name: 'Install RPM Tools'
           command: |
             sudo apt-get update -qq
-            sudo apt-get install -qq -y rpm
+            sudo apt-get install -qq -y rpm awscli
       - run:
           name: 'Install Vagrant'
           command: |
@@ -37,6 +37,11 @@ jobs:
           command: |
             export RPMBUILD_UID_MATCH=1
             make rpmbuild-hoot-release
+      - run:
+          name: 'Retrieve Latest Develop Archive'
+          command: |
+            LATEST_PREFIX="$(./scripts/latest-archive.sh -b hoot-archives -p circle/develop)"
+            aws s3 cp s3://hoot-archives/$LATEST_PREFIX SOURCES/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,9 @@ jobs:
     steps:
       - checkout
       - run:
-          name: 'Install RPM Tools'
+          name: 'Install RPM Tools and Vagrant'
           command: |
-            sudo ./scripts/rpm-install.sh
-      - run:
-          name: 'Install Vagrant'
-          command: |
+            ./scripts/rpm-install.sh
             ./scripts/vagrant-install.sh
       - run:
           name: 'Validate Vagrantfile'
@@ -50,9 +47,10 @@ jobs:
       - attach_workspace:
           at: images
       - run:
-          name: 'Install RPM Tools'
+          name: 'Install RPM Tools and Vagrant'
           command: |
-            sudo ./scripts/rpm-install.sh
+            ./scripts/rpm-install.sh
+            ./scripts/vagrant-install.sh
       - run:
           name: 'Load rpmbuild-hoot-release image'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: |
             MAVEN_CACHE=0 vagrant validate
       - run:
-          name: 'make rpmbuild-hoot-release'
+          name: 'Building rpmbuild-hoot-release'
           command: |
             export RPMBUILD_UID_MATCH=1
             make rpmbuild-hoot-release
@@ -42,7 +42,7 @@ jobs:
           root: images
           paths:
             - rpmbuild-hoot-release.tar
-  develop-update:
+  develop-rpm:
     machine:
       enabled: true
     steps:
@@ -53,19 +53,44 @@ jobs:
           name: 'Install RPM Tools'
           command: |
             sudo ./scripts/rpm-install.sh
+            sudo apt-get -qq -y install awscli
       - run:
           name: 'Load rpmbuild-hoot-release image'
           command: |
             docker load --input images/rpmbuild-hoot-release.tar
       - run:
-          name: 'Retrieve Latest Develop Archive'
+          name: 'Compile Latest Develop RPM'
           command: |
-            LATEST_PREFIX="$(./scripts/latest-archive.sh -b hoot-archives -p circle/develop)"
-            aws s3 cp s3://hoot-archives/$LATEST_PREFIX SOURCES/
-      # - run:
-      #     name: 'Make Hootenanny RPM from Archive'
-      #     command: |
-      #       make rpm
+            mkdir -p el7/develop
+            LATEST_ARCHIVE="$(./scripts/latest-archive.sh -b hoot-archives -p circle/develop)"
+            if [ "$(./scripts/query-archive.sh -a $LATEST_ARCHIVE -b hoot-repo -p el7/develop)" = "0" ]; then
+                aws s3 cp s3://hoot-archives/$LATEST_PREFIX SOURCES/
+                make rpm
+                mv -v RPMS/{noarch,x86_64}/*.rpm el7/develop
+            else
+                touch el7/develop/none.rpm
+            fi
+            sudo chown -R 1000:1000 el7/develop
+      - persist_to_workspace:
+          root: el7/develop
+          paths:
+            - *.rpm
+   develop-sync:
+     working_directory: '/rpmbuild/hootenanny-rpms'
+     docker:
+       - image: hootenanny/rpmbuild-repo@sha256:7147b62b7a6dded4b72003df0aca52ab4b667dba4da5c11a7ceb4b00bbacd120
+         user: rpmbuild
+     steps:
+       - attach_workspace:
+           at: el7/develop
+       - run:
+           name: 'Update and Sync Develop Repository'
+           command: |
+             if [ -f el7/develop/none.rpm ]; then
+                 echo "RPM has already been created."
+             else
+                 ./scripts/repo-sync -b hoot-repo -p el7/develop
+             fi
 
 workflows:
   version: 2
@@ -73,8 +98,9 @@ workflows:
     jobs:
       - lint
       - rpmbuild-hoot-release:
-          requires:
-            - lint
-      - develop-update:
+      - develop-rpm:
           requires:
             - rpmbuild-hoot-release
+      - develop-sync:
+          requires:
+            - develop-rpm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,13 @@ workflows:
       - develop-sync:
           requires:
             - develop-rpm
+    triggers:
+      - schedule:
+          cron: "30 16 * * *"
+          filters:
+            branches:
+              only:
+                - archive-rpm-pipeline
   tests:
     jobs:
       - lint

--- a/scripts/latest-archive.sh
+++ b/scripts/latest-archive.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euxo pipefail
+set -euo pipefail
 
 # Defaults.
 USAGE=no
@@ -34,7 +34,7 @@ fi
 
 # Use a query expression to determine the number of objects in the
 # bucket that match the prefix.
-NUM_ARCHIVES="$(aws s3api list-objects-v2 --debug --bucket "$BUCKET" --prefix "$PREFIX" --query "type(Contents[]) == \`array\` && length(Contents[]) || \`0\`")"
+NUM_ARCHIVES="$(aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "$PREFIX" --query "type(Contents[]) == \`array\` && length(Contents[]) || \`0\`")"
 
 if [ "$NUM_ARCHIVES" = "0" ]; then
     # Bail if no archives are found.
@@ -45,7 +45,6 @@ else
     # with reverse sorting on the last modified date for every object in the
     # query expression.
     aws s3api list-objects-v2 \
-        --debug \
         --bucket "$BUCKET" \
         --prefix "$PREFIX" \
         --output text \

--- a/scripts/latest-archive.sh
+++ b/scripts/latest-archive.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+# Defaults.
+USAGE=no
+BUCKET=""
+PREFIX=""
+
+while getopts ":b:p:" opt; do
+    case "$opt" in
+        b)
+            BUCKET="$OPTARG"
+            ;;
+        p)
+            PREFIX="$OPTARG"
+            ;;
+        *)
+            USAGE=yes
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+
+function usage() {
+    echo "latest-archive.sh: -b <S3 Bucket> -p <Bucket Prefix>"
+    exit 1
+}
+
+# Abort if invalid options.
+if [[ "$USAGE" = "yes" || -z "$BUCKET" || -z "$PREFIX" ]]; then
+    usage
+fi
+
+# Use a query expression to determine the number of objects in the
+# bucket that match the prefix.
+NUM_ARCHIVES="$(aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "$PREFIX" --query "type(Contents[]) == \`array\` && length(Contents[]) || \`0\`")"
+
+if [ "$NUM_ARCHIVES" = "0" ]; then
+    # Bail if no archives are found.
+    echo "No archives found in s3://$BUCKET/$PREFIX"
+    exit 2
+else
+    # Otherwise, just print out the key of the latest archive.  This is done
+    # with reverse sorting on the last modified date for every object in the
+    # query expression.
+    aws s3api list-objects-v2 \
+        --bucket "$BUCKET" \
+        --prefix "$PREFIX" \
+        --output text \
+        --query 'reverse(sort_by(Contents[].{LastModified: LastModified, Key: Key}, &LastModified))[0].Key'
+fi

--- a/scripts/latest-archive.sh
+++ b/scripts/latest-archive.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -euxo pipefail
 
 # Defaults.
 USAGE=no
@@ -34,7 +34,7 @@ fi
 
 # Use a query expression to determine the number of objects in the
 # bucket that match the prefix.
-NUM_ARCHIVES="$(aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "$PREFIX" --query "type(Contents[]) == \`array\` && length(Contents[]) || \`0\`")"
+NUM_ARCHIVES="$(aws s3api list-objects-v2 --debug --bucket "$BUCKET" --prefix "$PREFIX" --query "type(Contents[]) == \`array\` && length(Contents[]) || \`0\`")"
 
 if [ "$NUM_ARCHIVES" = "0" ]; then
     # Bail if no archives are found.
@@ -45,6 +45,7 @@ else
     # with reverse sorting on the last modified date for every object in the
     # query expression.
     aws s3api list-objects-v2 \
+        --debug \
         --bucket "$BUCKET" \
         --prefix "$PREFIX" \
         --output text \

--- a/scripts/latest-archive.sh
+++ b/scripts/latest-archive.sh
@@ -24,6 +24,7 @@ shift $((OPTIND-1))
 
 function usage() {
     echo "latest-archive.sh: -b <S3 Bucket> -p <Bucket Prefix>"
+    echo "  Prints the latest archive file hosted at the given S3 bucket and prefix."
     exit 1
 }
 

--- a/scripts/query-archive.sh
+++ b/scripts/query-archive.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+# Defaults.
+USAGE=no
+ARCHIVE=""
+BUCKET=""
+PREFIX=""
+
+while getopts ":a:b:p:" opt; do
+    case "$opt" in
+        a)
+            ARCHIVE="$OPTARG"
+            ;;
+        b)
+            BUCKET="$OPTARG"
+            ;;
+        p)
+            PREFIX="$OPTARG"
+            ;;
+        *)
+            USAGE=yes
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+
+function usage() {
+    echo "query-archive.sh: -a <Archive Name> -b <S3 Bucket> -p <Bucket Prefix>"
+    exit 1
+}
+
+# Abort if invalid options.
+if [[ "$USAGE" = "yes" || -z "$ARCHIVE" || -z "$BUCKET" || -z "$PREFIX" ]]; then
+    usage
+fi
+
+# Pull out the git commit from the archive filename.
+GIT_COMMIT="$(basename "$ARCHIVE" | awk -F_ "{ git_abbrev = \$3; sub(/.tar.gz/, \"\", git_abbrev); print substr(git_abbrev, 2) }")"
+
+# Query the number of RPMs
+aws s3api list-objects-v2 \
+    --bucket "$BUCKET" \
+    --prefix "$PREFIX" \
+    --query "length(Contents[?ends_with(Key, \`$GIT_COMMIT.el7.x86_64.rpm\`) && starts_with(Key, \`$PREFIX/hootenanny-core-\`)].Key)"

--- a/scripts/query-archive.sh
+++ b/scripts/query-archive.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euxo pipefail
+set -euo pipefail
 
 # Defaults.
 USAGE=no
@@ -41,7 +41,6 @@ GIT_COMMIT="$(basename "$ARCHIVE" | awk -F_ "{ git_abbrev = \$3; sub(/.tar.gz/, 
 
 # Query the number of RPMs
 aws s3api list-objects-v2 \
-    --debug \
     --bucket "$BUCKET" \
     --prefix "$PREFIX" \
     --query "length(Contents[?ends_with(Key, \`$GIT_COMMIT.el7.x86_64.rpm\`) && starts_with(Key, \`$PREFIX/hootenanny-core-\`)].Key)"

--- a/scripts/query-archive.sh
+++ b/scripts/query-archive.sh
@@ -28,6 +28,9 @@ shift $((OPTIND-1))
 
 function usage() {
     echo "query-archive.sh: -a <Archive Name> -b <S3 Bucket> -p <Bucket Prefix>"
+    echo "  Queries the yum repository for an RPM built from the archive"
+    echo "  hosted at the given S3 bucket and prefix.  Prints the number"
+    echo "  of RPMs found or '0' if none exist."
     exit 1
 }
 

--- a/scripts/query-archive.sh
+++ b/scripts/query-archive.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -euxo pipefail
 
 # Defaults.
 USAGE=no
@@ -41,6 +41,7 @@ GIT_COMMIT="$(basename "$ARCHIVE" | awk -F_ "{ git_abbrev = \$3; sub(/.tar.gz/, 
 
 # Query the number of RPMs
 aws s3api list-objects-v2 \
+    --debug \
     --bucket "$BUCKET" \
     --prefix "$PREFIX" \
     --query "length(Contents[?ends_with(Key, \`$GIT_COMMIT.el7.x86_64.rpm\`) && starts_with(Key, \`$PREFIX/hootenanny-core-\`)].Key)"

--- a/scripts/query-archive.sh
+++ b/scripts/query-archive.sh
@@ -17,6 +17,10 @@ while getopts ":a:b:p:" opt; do
             ;;
         p)
             PREFIX="$OPTARG"
+            if [ "${PREFIX: -1}" = "/" ]; then
+                echo "Prefix cannot end with a '/'."
+                exit 2
+            fi
             ;;
         *)
             USAGE=yes
@@ -42,8 +46,9 @@ fi
 # Pull out the git commit from the archive filename.
 GIT_COMMIT="$(basename "$ARCHIVE" | awk -F_ "{ git_abbrev = \$3; sub(/.tar.gz/, \"\", git_abbrev); print substr(git_abbrev, 2) }")"
 
-# Query the number of RPMs
+# Query the number of RPMs; have to append a "/" to prefix, otherwise AWS
+# won't allow the query expression.
 aws s3api list-objects-v2 \
     --bucket "$BUCKET" \
-    --prefix "$PREFIX" \
+    --prefix "$PREFIX/" \
     --query "length(Contents[?ends_with(Key, \`$GIT_COMMIT.el7.x86_64.rpm\`) && starts_with(Key, \`$PREFIX/hootenanny-core-\`)].Key)"

--- a/scripts/repo-sync.sh
+++ b/scripts/repo-sync.sh
@@ -6,6 +6,7 @@ DEST="$(pwd)"
 BUCKET=""
 KEEP="10"
 PREFIX=""
+QUIET=""
 UPLOAD="yes"
 USAGE="no"
 
@@ -15,7 +16,7 @@ PROFILE="${AWS_PROFILE:-default}"
 REGION="${AWS_DEFAULT_REGION:-us-east-1}"
 
 # Getting parameters from the command line.
-while getopts ":a:b:p:d:k:nr:" opt; do
+while getopts ":a:b:p:d:k:nqr:" opt; do
     case "${opt}" in
         # Required parameters.
         b)
@@ -36,6 +37,9 @@ while getopts ":a:b:p:d:k:nr:" opt; do
             ;;
         n)
             UPLOAD="no"
+            ;;
+        q)
+            QUIET="--quiet"
             ;;
         r)
             REGION="${OPTARG}"
@@ -125,6 +129,7 @@ else
         "$S3_URL"
         "$REPO"
         "--keep-newer"
+        "$QUIET"
         "${AWS_COMMON_OPTS[@]}"
     )
     aws s3 sync "${DOWNLOAD_OPTS[@]}"
@@ -142,6 +147,7 @@ if [ "$UPLOAD" == "yes" ]; then
         "$REPO"
         "$S3_URL"
         "--delete"
+        "$QUIET"
         "${AWS_COMMON_OPTS[@]}"
     )
     aws s3 sync "${UPLOAD_OPTS[@]}"

--- a/scripts/rpm-install.sh
+++ b/scripts/rpm-install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# Installs RPM tools on Debian and RHEL-like platforms.
+LSB_DIST="$(. /etc/os-release && echo "$ID")"
+if [ "$LSB_DIST" == 'centos' -o "$LSB_DIST" == 'fedora' -o "$LSB_DIST" == 'rhel' ]; then
+    yum install -q -y rpm-build
+elif [ "$LSB_DIST" == 'debian' -o "$LSB_DIST" == 'ubuntu' ]; then
+    apt-get update -qq
+    apt-get install -qq -y rpm
+fi

--- a/scripts/rpm-install.sh
+++ b/scripts/rpm-install.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 # Installs RPM tools on Debian and RHEL-like platforms.
 LSB_DIST="$(. /etc/os-release && echo "$ID")"
 if [ "$LSB_DIST" == 'centos' -o "$LSB_DIST" == 'fedora' -o "$LSB_DIST" == 'rhel' ]; then
-    yum install -q -y rpm-build
+    sudo yum install -q -y rpm-build
 elif [ "$LSB_DIST" == 'debian' -o "$LSB_DIST" == 'ubuntu' ]; then
-    apt-get update -qq
-    apt-get install -qq -y rpm
+    sudo apt-get update -qq
+    sudo apt-get install -qq -y rpm
 fi

--- a/tests/lint-bash.sh
+++ b/tests/lint-bash.sh
@@ -13,6 +13,7 @@ shellcheck \
     scripts/hoot-repo.sh \
     scripts/latest-archive.sh \
     scripts/query-archive.sh \
+    scripts/repo-sync.sh \
     scripts/repo-update.sh \
     scripts/rpm-install.sh \
     scripts/vagrant-install.sh
@@ -26,7 +27,6 @@ shellcheck \
     scripts/pgdg-repo.sh \
     scripts/postgresql-install.sh \
     scripts/repo-sign.sh \
-    scripts/repo-sync.sh \
     shell/BuildArchive.sh \
     shell/BuildDeps.sh \
     shell/BuildHoot.sh \

--- a/tests/lint-bash.sh
+++ b/tests/lint-bash.sh
@@ -13,6 +13,7 @@ shellcheck \
     scripts/hoot-repo.sh \
     scripts/latest-archive.sh \
     scripts/repo-update.sh \
+    scripts/rpm-install.sh \
     scripts/vagrant-install.sh
 
 # Scripts with *only* quoting errors.

--- a/tests/lint-bash.sh
+++ b/tests/lint-bash.sh
@@ -11,6 +11,7 @@ shellcheck \
     scripts/docker-install.sh \
     scripts/hoot-archive.sh \
     scripts/hoot-repo.sh \
+    scripts/latest-archive.sh \
     scripts/repo-update.sh \
     scripts/vagrant-install.sh
 

--- a/tests/lint-bash.sh
+++ b/tests/lint-bash.sh
@@ -12,6 +12,7 @@ shellcheck \
     scripts/hoot-archive.sh \
     scripts/hoot-repo.sh \
     scripts/latest-archive.sh \
+    scripts/query-archive.sh \
     scripts/repo-update.sh \
     scripts/rpm-install.sh \
     scripts/vagrant-install.sh


### PR DESCRIPTION
This PR enables an RPM pipeline that takes Hootenanny `develop` archives generated on by that repository's tests (added in ngageoint/hootenanny#2445), compiles RPMs from the archive, and updates the `develop` repository with the compiled RPMs.  An RPM won't be created if one already exists in the repository (it takes ~30 minutes to compile an RPM on the free CircleCI instance).

Some notes:
* A separate CircleCI workflow, `develop-repo`, is used so that it can be [triggered on a set schedule](https://circleci.com/docs/2.0/configuration-reference/#schedule)
* Determining the latest archive and if querying if that archive's git commit is already a part of the RPM in the repo are handled by the added `latest-archive.sh` and `query-archive.sh` scripts, respectively.  These are essentially just fancy wrappers around `aws s3api list-object-v2 --query` calls with fancy (and finicky) [JMESPath](http://jmespath.org/specification.html) expressions.
* After merging, this will need to be merged into `master` so that the triggered builds will work properly.
* The `rpm-install.sh` script was added to simplify RPM tool installation and `repo-sync.sh` was cleaned up to support not adding `--profile` when to the `aws s3 sync` invocation when unset.