### PR TITLE
Match invoking user's UID/GID by default.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,6 @@ jobs:
       - run:
           name: 'make rpmbuild-hoot-release'
           command: |
-            export RPMBUILD_UID_MATCH=1
             make rpmbuild-hoot-release
 
 workflows:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,10 +15,11 @@ $rpms = settings.fetch('rpms', {})
 $pg_version = settings.fetch('versions')['postgresql']
 $pg_dotless = $pg_version.gsub('.', '')
 
-# Special workaround if we want the `rpmbuild` UID and GID to match that of
+# Special workaround to have the `rpmbuild` UID and GID to match that of
 # the user invoking Vagrant, which simplifies file permissions for host
-# volume mounts.
-if ENV.key?('RPMBUILD_UID_MATCH')
+# volume mounts.  Setting the `RPMBUILD_UID_MATCH` variable to a value
+# other than '1' forces the UID/GID in the configuration file to be honored.
+if ENV.fetch('RPMBUILD_UID_MATCH', '1') == '1'
   $images['base']['rpmbuild']['args']['rpmbuild_uid'] = Process.uid
   $images['base']['rpmbuild']['args']['rpmbuild_gid'] = Process.gid
 end

--- a/doc/config.md
+++ b/doc/config.md
@@ -38,4 +38,4 @@ MAVEN_CACHE=0 vagrant status
 
 ### `RPMBUILD_UID_MATCH`
 
-By default, the containers use a UID of 1000 for the non-privileged `rpmbuild` user.  While this is the first-user ID on most Linux distributions, this is not universally true -- and will result in permission errors because the host's UID doesn't match that of the container because [Docker bind mounts](https://docs.docker.com/storage/bind-mounts/) are used .  Thus, if you want the `rpmbuild` container user to match that of the host user invoking `docker`, set the `RPMBUILD_UID_MATCH` environment variable to any value.
+By default, the containers use a UID and GID matching the invoking user for `rpmbuild`; doing so prevents permission errors because [Docker bind mounts](https://docs.docker.com/storage/bind-mounts/) are used to share files with the hootenanny containers.  If you want the `rpmbuild` user to have the same UID/GID specified in `config.yml`, set `RPMBUILD_UID_MATCH=0` (any value other than `1`).


### PR DESCRIPTION
Fixes #214, make UID/GID matching the default behavior.