### PR TITLE
Slack Notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,13 +94,13 @@ workflows:
       - develop-sync:
           requires:
             - develop-rpm
-  #  triggers:
-  #    - schedule:
-  #        cron: "0 12,20 * * *"
-  #        filters:
-  #          branches:
-  #            only:
-  #              - develop
+    triggers:
+      - schedule:
+          cron: "0 12,20 * * *"
+          filters:
+            branches:
+              only:
+                - develop
   tests:
     jobs:
       - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
             if [ -f el7/develop/none.rpm ]; then
                 echo "RPM has already been created."
             else
-                ./scripts/repo-sync.sh -a "" -b hoot-repo -p el7/develop -q
+                ./scripts/repo-sync.sh -b hoot-repo -p el7/develop -q
             fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
                RPM_FILE="$(ls -1t el7/develop-test/hootenanny-autostart-*noarch.rpm | head -n 1)"
                RPM_VERSION="$(echo "$RPM_FILE" | awk 'match($0, /hootenanny-autostart-(.+).noarch.rpm$/, a) { print a[1] }')"
                ./scripts/repo-sync.sh -b hoot-repo -p el7/develop-test -q
-               ./scripts/slack-notify \
+               ./scripts/slack-notify.sh \
                  -c test \
                  -t $SLACK_TOKEN \
                  -u circleci_bot \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,14 @@ jobs:
             if [ -f el7/develop-test/none.rpm ]; then
                 echo "RPM has already been created."
             else
-               RPM_VERSION="$(ls -1t el7/develop-test/hootenanny-autostart-*noarch.rpm | head -n 1 | awk 'match($0, /hootenanny-autostart-(.+).noarch.rpm$/, a) { print a[1] }')"
+               RPM_FILE="$(ls -1t el7/develop-test/hootenanny-autostart-*noarch.rpm | head -n 1)"
+               RPM_VERSION="$(echo "$RPM_FILE" | awk 'match($0, /hootenanny-autostart-(.+).noarch.rpm$/, a) { print a[1] }')"
                ./scripts/repo-sync.sh -b hoot-repo -p el7/develop-test -q
-               ./scripts/slack-notify -c test -t $SLACK_TOKEN -u circleci_bot -m "Hootenanny Develop RPMs Updated to $RPM_VERSION"
+               ./scripts/slack-notify \
+                 -c test \
+                 -t $SLACK_TOKEN \
+                 -u circleci_bot \
+                 -m "Hootenanny Develop RPMs Updated to $RPM_VERSION"
             fi
 
 workflows:
@@ -89,13 +94,13 @@ workflows:
       - develop-sync:
           requires:
             - develop-rpm
-    # triggers:
-    #   - schedule:
-    #       cron: "0 12,20 * * *"
-    #       filters:
-    #         branches:
-    #           only:
-    #             - develop
+  #  triggers:
+  #    - schedule:
+  #        cron: "0 12,20 * * *"
+  #        filters:
+  #          branches:
+  #            only:
+  #              - develop
   tests:
     jobs:
       - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,21 +44,21 @@ jobs:
       - run:
           name: 'Compile Latest Develop RPM'
           command: |
-            mkdir -p cache/m2 cache/npm el7/develop RPMS
+            mkdir -p cache/m2 cache/npm el7/develop-test RPMS
             LATEST_ARCHIVE="$(./scripts/latest-archive.sh -b hoot-archives -p circle/develop)"
-            if [ "$(./scripts/query-archive.sh -a $LATEST_ARCHIVE -b hoot-repo -p el7/develop)" = "0" ]; then
+            if [ "$(./scripts/query-archive.sh -a $LATEST_ARCHIVE -b hoot-repo -p el7/develop-test)" = "0" ]; then
                 aws s3 cp s3://hoot-archives/$LATEST_ARCHIVE SOURCES/
                 source shell/Vars.sh
                 maven_cache
                 sudo chown -R 1000:1000 cache RPMS SOURCES
                 ./shell/BuildHoot.sh
-                sudo mv -v RPMS/{noarch,x86_64}/*.rpm el7/develop
+                sudo mv -v RPMS/{noarch,x86_64}/*.rpm el7/develop-test
             else
-                touch el7/develop/none.rpm
+                touch el7/develop-test/none.rpm
             fi
-            sudo chown -R 1000:1000 el7/develop
+            sudo chown -R 1000:1000 el7/develop-test
       - persist_to_workspace:
-          root: el7/develop
+          root: el7/develop-test
           paths:
             - "*.rpm"
   develop-sync:
@@ -69,14 +69,16 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: el7/develop
+          at: el7/develop-test
       - run:
           name: 'Update and Sync Develop Repository'
           command: |
-            if [ -f el7/develop/none.rpm ]; then
+            if [ -f el7/develop-test/none.rpm ]; then
                 echo "RPM has already been created."
             else
-                ./scripts/repo-sync.sh -b hoot-repo -p el7/develop -q
+               RPM_VERSION="$(ls -1t el7/develop-test/hootenanny-autostart-*noarch.rpm | head -n 1 | awk 'match($0, /hootenanny-autostart-(.+).noarch.rpm$/, a) { print a[1] }')"
+               ./scripts/repo-sync.sh -b hoot-repo -p el7/develop-test -q
+               ./scripts/slack-notify -c test -t $SLACK_TOKEN -u circleci_bot -m "Hootenanny Develop RPMs Updated to $RPM_VERSION"
             fi
 
 workflows:
@@ -87,13 +89,13 @@ workflows:
       - develop-sync:
           requires:
             - develop-rpm
-    triggers:
-      - schedule:
-          cron: "0 12,20 * * *"
-          filters:
-            branches:
-              only:
-                - develop
+    # triggers:
+    #   - schedule:
+    #       cron: "0 12,20 * * *"
+    #       filters:
+    #         branches:
+    #           only:
+    #             - develop
   tests:
     jobs:
       - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,21 +44,21 @@ jobs:
       - run:
           name: 'Compile Latest Develop RPM'
           command: |
-            mkdir -p cache/m2 cache/npm el7/develop-test RPMS
+            mkdir -p cache/m2 cache/npm el7/develop RPMS
             LATEST_ARCHIVE="$(./scripts/latest-archive.sh -b hoot-archives -p circle/develop)"
-            if [ "$(./scripts/query-archive.sh -a $LATEST_ARCHIVE -b hoot-repo -p el7/develop-test)" = "0" ]; then
+            if [ "$(./scripts/query-archive.sh -a $LATEST_ARCHIVE -b hoot-repo -p el7/develop)" = "0" ]; then
                 aws s3 cp s3://hoot-archives/$LATEST_ARCHIVE SOURCES/
                 source shell/Vars.sh
                 maven_cache
                 sudo chown -R 1000:1000 cache RPMS SOURCES
                 ./shell/BuildHoot.sh
-                sudo mv -v RPMS/{noarch,x86_64}/*.rpm el7/develop-test
+                sudo mv -v RPMS/{noarch,x86_64}/*.rpm el7/develop
             else
-                touch el7/develop-test/none.rpm
+                touch el7/develop/none.rpm
             fi
-            sudo chown -R 1000:1000 el7/develop-test
+            sudo chown -R 1000:1000 el7/develop
       - persist_to_workspace:
-          root: el7/develop-test
+          root: el7/develop
           paths:
             - "*.rpm"
   develop-sync:
@@ -69,21 +69,21 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: el7/develop-test
+          at: el7/develop
       - run:
           name: 'Update and Sync Develop Repository'
           command: |
-            if [ -f el7/develop-test/none.rpm ]; then
+            if [ -f el7/develop/none.rpm ]; then
                 echo "RPM has already been created."
             else
-               RPM_FILE="$(ls -1t el7/develop-test/hootenanny-autostart-*noarch.rpm | head -n 1)"
+               RPM_FILE="$(ls -1t el7/develop/hootenanny-autostart-*noarch.rpm | head -n 1)"
                RPM_VERSION="$(echo "$RPM_FILE" | awk 'match($0, /hootenanny-autostart-(.+).noarch.rpm$/, a) { print a[1] }')"
-               ./scripts/repo-sync.sh -b hoot-repo -p el7/develop-test -q
+               ./scripts/repo-sync.sh -b hoot-repo -p el7/develop -q
                ./scripts/slack-notify.sh \
-                 -c test \
+                 -c $SLACK_CHANNEL \
                  -t $SLACK_TOKEN \
                  -u circleci_bot \
-                 -m "Hootenanny Develop RPMs Updated to $RPM_VERSION"
+                 -m "Hootenanny Develop Repository Updated to \`$RPM_VERSION\`"
             fi
 
 workflows:

--- a/scripts/repo-sync.sh
+++ b/scripts/repo-sync.sh
@@ -12,7 +12,7 @@ USAGE="no"
 
 # These variables default to value of AWS CLI environment
 # variables (if defined).
-PROFILE="${AWS_PROFILE:-default}"
+PROFILE="${AWS_PROFILE:-}"
 REGION="${AWS_DEFAULT_REGION:-us-east-1}"
 
 # Getting parameters from the command line.

--- a/scripts/slack-notify.sh
+++ b/scripts/slack-notify.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+
+# Defaults.
+SLACK_METHOD="https://slack.com/api/chat.postMessage"
+SLACK_CHANNEL=""
+SLACK_MESSAGE=""
+SLACK_TOKEN=""
+SLACK_USERNAME="bot"
+USAGE="no"
+
+# Retrieving command-line options.
+while getopts ":c:m:t:u:" opt; do
+    case "$opt" in
+        c)
+            SLACK_CHANNEL="$OPTARG"
+            ;;
+        m)
+            SLACK_MESSAGE="$OPTARG"
+            ;;
+        t)
+            SLACK_TOKEN="$OPTARG"
+            ;;
+        u)
+            SLACK_USERNAME="$OPTARG"
+            ;;
+        *)
+            USAGE=yes
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+# Document the usage for this script.
+function usage() {
+    echo "slack-notify.sh -c <Slack Channel> -m <Slack Message> -t <Slack Token>"
+    echo "  [ -u <Slack Username> ]"
+    echo ""
+    echo "  Sends a text notification to the given Slack channel."
+    exit 1
+}
+
+if [ -z "$SLACK_CHANNEL" -o -z "$SLACK_MESSAGE" -o -z "$SLACK_TOKEN" ]; then
+    USAGE=yes
+fi
+
+if [ "$USAGE" = "yes" ]; then
+    usage
+fi
+
+# Use cURL's `--form` option to automatically set to POST and use the proper
+# content type.
+curl \
+    --form channel="$SLACK_CHANNEL" \
+    --form text="$SLACK_MESSAGE" \
+    --form token="$SLACK_TOKEN" \
+    --form username="$SLACK_USERNAME" \
+    --show-error \
+    --silent \
+    "$SLACK_METHOD"

--- a/scripts/vagrant-install.sh
+++ b/scripts/vagrant-install.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #  * VAGRANT_VERSION
 #  * VAGRANT_BASEURL
 LSB_DIST="$(. /etc/os-release && echo "$ID")"
-VAGRANT_VERSION="${VAGRANT_VERSION:-2.1.1}"
+VAGRANT_VERSION="${VAGRANT_VERSION:-2.1.2}"
 VAGRANT_BASEURL="${VAGRANT_BASEURL:-https://releases.hashicorp.com/vagrant/$VAGRANT_VERSION}"
 
 # Set up command differences between RHEL and Debian-based systems.

--- a/tests/lint-bash.sh
+++ b/tests/lint-bash.sh
@@ -16,6 +16,7 @@ shellcheck \
     scripts/repo-sync.sh \
     scripts/repo-update.sh \
     scripts/rpm-install.sh \
+    scripts/slack-notify.sh \
     scripts/sonar-install.sh \
     scripts/vagrant-install.sh
 


### PR DESCRIPTION
This enables Slack notifications upon updates to the `develop` RPM repository.  It uses the added `scripts/slack-notify.sh` script using the release information from the autostart RPM package.

Additional changes:
* Remove AWS profile usage by default in `repo-sync.sh` (a747682).
* Upgrade to Vagrant 2.1.2 (2b8b5b5).