### PR TITLE
RPM_VERSION hotfix

### DIFF
--- a/tests/update-sync-repo.sh
+++ b/tests/update-sync-repo.sh
@@ -23,6 +23,10 @@ SLACK_USER="${SLACK_USER:-circleci_bot}"
 if [ -f el7/none.rpm ]; then
     echo "RPM has already been created."
 else
+    # Get the version of the RPM in the workspace.
+    RPM_FILE="$(find el7 -type f -name hootenanny-autostart-\*noarch.rpm | head -n 1)"
+    RPM_VERSION="$(echo "$RPM_FILE" | awk 'match($0, /hootenanny-autostart-(.+).noarch.rpm$/, a) { print a[1] }')"
+
     # Synchronize the new RPMs from the workspace with those in the
     # repository bucket/prefix.
     ./scripts/repo-sync.sh -d el7 -b "$REPO_BUCKET" -p "$REPO_PREFIX" -q


### PR DESCRIPTION
During testing of #221 I disabled slack notifications and missed that I didn't include the setting of `$RPM_VERSION`.  I'm bringing it back here, otherwise the script will fail after sync and there'll be no slack message (due to `set -u`).  In addition, I used `find` instead of `ls` because `shellcheck` will fail otherwise with:

> SC2012: Use find instead of ls to better handle non-alphanumeric filenames.
