### PR TITLE
Test RPM Installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,8 @@ jobs:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
       - image: hootenanny/run-base-release@sha256:d795cdf73f5841beeca7738435d0407b8aeb890ee79612cc687b69d167effa9c
+        environment:
+          HOOT_TESTS: disable
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,8 @@ jobs:
   develop-rpm:
     machine:
       enabled: true
+    environment:
+      REPO_PREFIX: el7/develop-test
     steps:
       - checkout
       - run:
@@ -49,10 +51,25 @@ jobs:
           root: el7
           paths:
             - "*.rpm"
+  develop-install:
+    working_directory: '/rpmbuild/hootenanny-rpms'
+    docker:
+      - image: hootenanny/run-base-release@sha256:d795cdf73f5841beeca7738435d0407b8aeb890ee79612cc687b69d167effa9c
+    steps:
+      - checkout
+      - attach_workspace:
+          at: el7
+      - run:
+          name: 'Test RPM installation and Run Core Hootenanny Tests'
+          command: |
+            ./tests/install-test-rpm.sh
   develop-sync:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
       - image: hootenanny/rpmbuild-repo@sha256:7147b62b7a6dded4b72003df0aca52ab4b667dba4da5c11a7ceb4b00bbacd120
+        environment:
+          REPO_PREFIX: el7/develop-test
+          SLACK_CHANNEL: test
         user: rpmbuild
     steps:
       - checkout
@@ -68,16 +85,12 @@ workflows:
   develop-repo:
     jobs:
       - develop-rpm
-      - develop-sync:
+      - develop-install:
           requires:
             - develop-rpm
-    triggers:
-      - schedule:
-          cron: "0 12,20 * * *"
-          filters:
-            branches:
-              only:
-                - develop
+      - develop-sync:
+          requires:
+            - develop-install
   tests:
     jobs:
       - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,6 @@ jobs:
   develop-rpm:
     machine:
       enabled: true
-    environment:
-      REPO_PREFIX: el7/develop-test
     steps:
       - checkout
       - run:
@@ -69,9 +67,6 @@ jobs:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
       - image: hootenanny/rpmbuild-repo@sha256:7147b62b7a6dded4b72003df0aca52ab4b667dba4da5c11a7ceb4b00bbacd120
-        environment:
-          REPO_PREFIX: el7/develop-test
-          SLACK_CHANNEL: test
         user: rpmbuild
     steps:
       - checkout
@@ -93,6 +88,13 @@ workflows:
       - develop-sync:
           requires:
             - develop-install
+    triggers:
+      - schedule:
+          cron: "0 12,20 * * *"
+          filters:
+            branches:
+              only:
+                - develop
   tests:
     jobs:
       - lint

--- a/tests/install-test-rpm.sh
+++ b/tests/install-test-rpm.sh
@@ -40,5 +40,5 @@ else
 
     # Run Hootenanny tests.
     cd /var/lib/hootenanny
-    su-exec tomcat HootTest --diff --glacial --parallel 4
+    su-exec tomcat HootTest --diff --slow --parallel "$(nproc)
 fi

--- a/tests/install-test-rpm.sh
+++ b/tests/install-test-rpm.sh
@@ -40,5 +40,5 @@ else
 
     # Run Hootenanny tests.
     cd /var/lib/hootenanny
-    su-exec tomcat HootTest --diff --glacial --parallel 8
+    su-exec tomcat HootTest --diff --glacial --parallel 4
 fi

--- a/tests/install-test-rpm.sh
+++ b/tests/install-test-rpm.sh
@@ -40,5 +40,5 @@ else
 
     # Run Hootenanny tests.
     cd /var/lib/hootenanny
-    su-exec tomcat HootTest --diff --slow --parallel "$(nproc)"
+    su-exec tomcat HootTest --diff --quick --parallel "$(nproc)"
 fi

--- a/tests/install-test-rpm.sh
+++ b/tests/install-test-rpm.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright (C) 2018 Radiant Solutions (http://www.radiantsolutions.com)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+set -euxo pipefail
+
+if [ -f el7/none.rpm ]; then
+    echo "No new RPM to install and test with."
+else
+    # Determine the version of the RPMs in the workspace.
+    RPM_FILE="$(ls -1t el7/hootenanny-autostart-*noarch.rpm | head -n 1)"
+    RPM_VERSION="$(echo "$RPM_FILE" | awk 'match($0, /hootenanny-autostart-(.+).noarch.rpm$/, a) { print a[1] }')"
+
+    # Manually install Hootenanny from the workspace RPMs.
+    yum install -y "el7/hootenanny-core-deps-$RPM_VERSION.noarch.rpm"
+    yum install -y "el7/hootenanny-core-$RPM_VERSION.x86_64.rpm"
+    yum install -y "el7/hootenanny-services-ui-$RPM_VERSION.x86_64.rpm"
+
+    # Setup database for testing.
+    ./scripts/hoot-db-setup.sh
+    su-exec postgres pg_ctl -D "$PGDATA" -s start
+
+    # Start Tomcat and node-export and send output to logfiles.
+    touch /var/log/{node-export,tomcat8}.log
+    chown tomcat:tomcat /var/log/{node-export,tomcat8}.log
+    su-exec tomcat /usr/libexec/tomcat8/server start &> /var/log/tomcat8.log &
+    su-exec tomcat bash -c "cd /var/lib/hootenanny/node-export-server && npm start" &> /var/log/node-export.log &
+
+    # Run Hootenanny tests.
+    cd /var/lib/hootenanny
+    su-exec tomcat HootTest --diff --glacial --parallel "$(nproc)"
+fi

--- a/tests/install-test-rpm.sh
+++ b/tests/install-test-rpm.sh
@@ -19,7 +19,7 @@ if [ -f el7/none.rpm ]; then
     echo "No new RPM to install and test with."
 else
     # Determine the version of the RPMs in the workspace.
-    RPM_FILE="$(ls -1t el7/hootenanny-autostart-*noarch.rpm | head -n 1)"
+    RPM_FILE="$(find el7 -type f -name hootenanny-autostart-\*noarch.rpm | head -n 1)"
     RPM_VERSION="$(echo "$RPM_FILE" | awk 'match($0, /hootenanny-autostart-(.+).noarch.rpm$/, a) { print a[1] }')"
 
     # Manually install Hootenanny from the workspace RPMs.
@@ -28,6 +28,7 @@ else
     yum install -y "el7/hootenanny-services-ui-$RPM_VERSION.x86_64.rpm"
 
     # Setup database for testing.
+    ./scripts/postgresql-install.sh
     ./scripts/hoot-db-setup.sh
     su-exec postgres pg_ctl -D "$PGDATA" -s start
 

--- a/tests/install-test-rpm.sh
+++ b/tests/install-test-rpm.sh
@@ -15,8 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 set -euxo pipefail
 
-HOOT_TESTS="yes"
-HOOT_TESTS_PARALLEL="$(nproc)"
+HOOT_TESTS="${HOOT_TESTS:-yes}"
+HOOT_TESTS_PARALLEL="${HOOT_TESTS_PARALLEL:-$(nproc)}"
 
 if [ -f el7/none.rpm ]; then
     echo "No new RPM to install and test with."

--- a/tests/install-test-rpm.sh
+++ b/tests/install-test-rpm.sh
@@ -40,5 +40,5 @@ else
 
     # Run Hootenanny tests.
     cd /var/lib/hootenanny
-    su-exec tomcat HootTest --diff --glacial --parallel "$(nproc)"
+    su-exec tomcat HootTest --diff --glacial --parallel 8
 fi

--- a/tests/install-test-rpm.sh
+++ b/tests/install-test-rpm.sh
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-set -euxo pipefail
+set -euo pipefail
 
 HOOT_TESTS="${HOOT_TESTS:-yes}"
 HOOT_TESTS_PARALLEL="${HOOT_TESTS_PARALLEL:-$(nproc)}"

--- a/tests/install-test-rpm.sh
+++ b/tests/install-test-rpm.sh
@@ -40,5 +40,5 @@ else
 
     # Run Hootenanny tests.
     cd /var/lib/hootenanny
-    su-exec tomcat HootTest --diff --slow --parallel "$(nproc)
+    su-exec tomcat HootTest --diff --slow --parallel "$(nproc)"
 fi

--- a/tests/install-test-rpm.sh
+++ b/tests/install-test-rpm.sh
@@ -15,6 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 set -euxo pipefail
 
+HOOT_TESTS="yes"
+HOOT_TESTS_PARALLEL="$(nproc)"
+
 if [ -f el7/none.rpm ]; then
     echo "No new RPM to install and test with."
 else
@@ -27,18 +30,20 @@ else
     yum install -y "el7/hootenanny-core-$RPM_VERSION.x86_64.rpm"
     yum install -y "el7/hootenanny-services-ui-$RPM_VERSION.x86_64.rpm"
 
-    # Setup database for testing.
-    ./scripts/postgresql-install.sh
-    ./scripts/hoot-db-setup.sh
-    su-exec postgres pg_ctl -D "$PGDATA" -s start
+    if [ "$HOOT_TESTS" = "yes" ]; then
+        # Setup database for testing.
+        ./scripts/postgresql-install.sh
+        ./scripts/hoot-db-setup.sh
+        su-exec postgres pg_ctl -D "$PGDATA" -s start
 
-    # Start Tomcat and node-export and send output to logfiles.
-    touch /var/log/{node-export,tomcat8}.log
-    chown tomcat:tomcat /var/log/{node-export,tomcat8}.log
-    su-exec tomcat /usr/libexec/tomcat8/server start &> /var/log/tomcat8.log &
-    su-exec tomcat bash -c "cd /var/lib/hootenanny/node-export-server && npm start" &> /var/log/node-export.log &
+        # Start Tomcat and node-export and send output to logfiles.
+        touch /var/log/{node-export,tomcat8}.log
+        chown tomcat:tomcat /var/log/{node-export,tomcat8}.log
+        su-exec tomcat /usr/libexec/tomcat8/server start &> /var/log/tomcat8.log &
+        su-exec tomcat bash -c "cd /var/lib/hootenanny/node-export-server && npm start" &> /var/log/node-export.log &
 
-    # Run Hootenanny tests.
-    cd /var/lib/hootenanny
-    su-exec tomcat HootTest --diff --quick --parallel "$(nproc)"
+        # Run Hootenanny tests.
+        cd /var/lib/hootenanny
+        su-exec tomcat HootTest --diff --quick --names --parallel "$HOOT_TESTS_PARALLEL"
+    fi
 fi


### PR DESCRIPTION
This PR adds a new testing script, `test-rpm-install.sh`, that tests installing the created RPMs prior to syncing with our repository in S3.  I also added the capability to run Hootenanny unit tests, but the CircleCI testing containers would be consistently killed; paring down to just the "quick" tests was even too much.  Thus, the functionality of the RPMs (can they be installed) is tested, but the running the unit tests has to be punted to until more memory is available or creating a separate Jenkins pipeline.