### PR TITLE
Tomcat 8.5.34

### DIFF
--- a/SPECS/tomcat8.spec
+++ b/SPECS/tomcat8.spec
@@ -90,7 +90,7 @@ find . -type f \( -name "*.bat" -o -name "*.tmp" \) -delete
 
 # Copy all, but omit documentation.
 %{__cp} -R * %{buildroot}%{tomcat_home}/
-%{__rm} -rf %{buildroot}%{tomcat_home}/{LICENSE,NOTICE,RELEASE-NOTES,RUNNING.txt,temp,work}
+%{__rm} -rf %{buildroot}%{tomcat_home}/{BUILDING.txt,CONTRIBUTING.md,LICENSE,NOTICE,README.md,RELEASE-NOTES,RUNNING.txt,temp,work}
 
 # Remove all webapps. Put webapps in /var/lib.
 %{__rm} -rf %{buildroot}%{tomcat_home}/webapps

--- a/SPECS/tomcat8.spec
+++ b/SPECS/tomcat8.spec
@@ -46,8 +46,8 @@ Version:    %{major_version}.%{minor_version}.%{micro_version}
 Release:    %{rpmbuild_release}%{?dist}
 License:    ASL 2.0
 Group:      Networking/Daemons
-URL:        http://tomcat.apache.org/
-Source0:    http://www.apache.org/dist/tomcat/tomcat-%{major_version}/v%{version}/bin/apache-tomcat-%{version}.tar.gz
+URL:        https://tomcat.apache.org/
+Source0:    https://www.apache.org/dist/tomcat/tomcat-%{major_version}/v%{version}/bin/apache-tomcat-%{version}.tar.gz
 Source1:    %{name}.conf
 Source2:    %{name}.functions
 Source3:    %{name}.logrotate

--- a/SPECS/tomcat8.spec
+++ b/SPECS/tomcat8.spec
@@ -215,6 +215,9 @@ getent passwd %{tomcat_user} 2>/dev/null || \
 %systemd_postun %{name}.service
 
 %changelog
+* Mon Sep 24 2018 Justin Bronn <justin.bronn@radiantsolutions.com> - 8.5.34-1
+- Upgrade to 8.5.34
+
 * Tue Jul 10 2018 Justin Bronn <justin.bronn@radiantsolutions.com> - 8.5.32-1
 - Upgrade to 8.5.32
 

--- a/config.yml
+++ b/config.yml
@@ -15,7 +15,7 @@ versions:
   postgresql: &pg_version '9.5'
   stxxl: &stxxl_version '1.3.1-1'
   su-exec: &suexec_version '0.2-1'
-  tomcat8: &tomcat8_version '8.5.32-1'
+  tomcat8: &tomcat8_version '8.5.34-1'
   wamerican-insane: &wamerican_version '7.1-1'
 
 


### PR DESCRIPTION
This upgrades the `tomcat8` package to 8.5.34.  A signed candidate package is available in S3, and may be used with the following Yum repo configuration:

```
[hoot-deps]
name = Hootenanny Dependencies
baseurl = https://s3.amazonaws.com/hoot-repo/el7/deps/upgrade
enabled = 1
gpgcheck = 1
repo_gpgcheck = 1
gpgkey = https://s3.amazonaws.com/hoot-repo/el7/hoot.gpg
```