### PR TITLE
PostGIS 2.4 Hotfix

### DIFF
--- a/SPECS/hoot-postgis24.spec
+++ b/SPECS/hoot-postgis24.spec
@@ -58,7 +58,7 @@ Requires:	pcre
 Requires(post):	%{_sbindir}/update-alternatives
 
 Provides:	%{sname} = %{version}-%{release}
-Conflicts:	%{sname}%{postgisprev_dotless}_%{pg_dotless}
+Provides:	%{sname}%{postgisprev_dotless}_%{pg_dotless} = %{version}-%{release}
 Conflicts:	postgis
 Conflicts:	postgis%{postgiscurrmajorversion}_%{pg_dotless}
 
@@ -75,7 +75,7 @@ Summary:	Client tools and their libraries of PostGIS
 Group:		Applications/Databases
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 Provides:	%{sname}-client = %{version}-%{release}
-Conflicts:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-client
+Provides:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-client = %{version}-%{release}
 Conflicts:	postgis-client
 Conflicts:	postgis%{postgiscurrmajorversion}_%{pg_dotless}-client
 
@@ -88,7 +88,7 @@ Summary:	Development headers and libraries for PostGIS
 Group:		Development/Libraries
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 Provides:	%{sname}-devel = %{version}-%{release}
-Conflicts:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-devel
+Provides:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-devel = %{version}-%{release}
 Conflicts:	postgis-devel
 Conflicts:	postgis%{postgiscurrmajorversion}_%{pg_dotless}-devel
 
@@ -100,7 +100,7 @@ with PostGIS.
 %package docs
 Summary:	Extra documentation for PostGIS
 Group:		Applications/Databases
-Conflicts:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-docs
+Provides:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-docs = %{version}-%{release}
 Conflicts:	postgis-docs
 Conflicts:	postgis%{postgiscurrmajorversion}_%{pg_dotless}-docs
 
@@ -114,7 +114,7 @@ Group:		Applications/Databases
 Requires:	%{name} = %{version}-%{release}
 Requires:	perl-DBD-Pg
 Provides:	%{sname}-utils = %{version}-%{release}
-Conflicts:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-utils
+Provides:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-utils = %{version}-%{release}
 Conflicts:	postgis-utils
 Conflicts:	postgis%{postgiscurrmajorversion}_%{pg_dotless}-utils
 

--- a/SPECS/hoot-postgis24.spec
+++ b/SPECS/hoot-postgis24.spec
@@ -138,9 +138,9 @@ The %{name}-utils package provides the utilities for PostGIS.
         --without-raster \
 %endif
 %if %{sfcgal}
-	--with-sfcgal=%{_bindir}/sfcgal-config \
+        --with-sfcgal=%{_bindir}/sfcgal-config \
 %endif
-	--disable-rpath --libdir=%{pginstdir}/lib
+        --disable-rpath --libdir=%{pginstdir}/lib
 
 %{__make} LPATH=`%{pginstdir}/bin/pg_config --pkglibdir` shlib="%{name}.so"
 %{__make} -C extensions
@@ -155,7 +155,7 @@ The %{name}-utils package provides the utilities for PostGIS.
 
 %if %utils
 %{__install} -d %{buildroot}%{_datadir}/%{name}
-%{__install} -m 644 utils/*.pl %{buildroot}%{_datadir}/%{name}
+%{__install} -m 0644 utils/*.pl %{buildroot}%{_datadir}/%{name}
 %endif
 
 # Create symlink of .so file. PostGIS hackers said that this is safe:
@@ -170,7 +170,7 @@ The %{name}-utils package provides the utilities for PostGIS.
 %postun
 if [ "$1" -eq 0 ]
   then
-      	# Only remove these links if the package is completely removed from the system (vs.just being upgraded)
+        # Only remove these links if the package is completely removed from the system (vs.just being upgraded)
         %{_sbindir}/update-alternatives --remove postgis-pgsql2shp	%{pginstdir}/bin/pgsql2shp
         %{_sbindir}/update-alternatives --remove postgis-shp2pgsql	%{pginstdir}/bin/shp2pgsql
 fi
@@ -200,7 +200,7 @@ fi
 %{pginstdir}/share/contrib/postgis-%{postgismajorversion}/*sfcgal*.sql
 %endif
 %{pginstdir}/lib/postgis-%{postgisprevmajorversion}.so
-%attr(755,root,root) %{pginstdir}/lib/postgis-%{postgismajorversion}.so
+%attr(0755,root,root) %{pginstdir}/lib/postgis-%{postgismajorversion}.so
 %{pginstdir}/share/extension/postgis-*.sql
 %if %{sfcgal}
 %{pginstdir}/share/extension/postgis_sfcgal*.sql
@@ -227,10 +227,10 @@ fi
 %endif
 
 %files client
-%defattr(644,root,root)
-%attr(755,root,root) %{pginstdir}/bin/pgsql2shp
-%attr(755,root,root) %{pginstdir}/bin/raster2pgsql
-%attr(755,root,root) %{pginstdir}/bin/shp2pgsql
+%defattr(0644,root,root)
+%attr(0755,root,root) %{pginstdir}/bin/pgsql2shp
+%attr(0755,root,root) %{pginstdir}/bin/raster2pgsql
+%attr(0755,root,root) %{pginstdir}/bin/shp2pgsql
 
 %files devel
 %defattr(644,root,root)
@@ -243,7 +243,7 @@ fi
 %files utils
 %defattr(-,root,root)
 %doc utils/README
-%attr(755,root,root) %{_datadir}/%{name}/*.pl
+%attr(0755,root,root) %{_datadir}/%{name}/*.pl
 %endif
 
 %files docs
@@ -251,8 +251,8 @@ fi
 %doc postgis-%{version}.pdf
 
 %changelog
-* Wed Oct 03 2018 Justin Bronn <justin.bronn@radiantsolutions.com> - 2.4.4-2
-- Fix packaging issues with initial 2.4.4-1 release.
+* Fri Oct 05 2018 Justin Bronn <justin.bronn@radiantsolutions.com> - 2.4.4-2
+- Fix packaging issues in initial release.
 
 * Mon Sep 24 2018 Justin Bronn <justin.bronn@radiantsolutions.com> - 2.4.4-1
 - Initial release, version 2.4.4.

--- a/SPECS/hoot-postgis24.spec
+++ b/SPECS/hoot-postgis24.spec
@@ -57,7 +57,7 @@ Requires:	proj
 Requires:	pcre
 Requires(post):	%{_sbindir}/update-alternatives
 
-Provides:	%{sname} = %{version}-%{release}
+Provides:	%{sname}%{pg_dotless} = %{version}-%{release}
 Provides:	%{sname}%{postgisprev_dotless}_%{pg_dotless} = %{version}-%{release}
 Conflicts:	postgis
 Conflicts:	postgis%{postgiscurrmajorversion}_%{pg_dotless}
@@ -74,7 +74,7 @@ certified as compliant with the "Types and Functions" profile.
 Summary:	Client tools and their libraries of PostGIS
 Group:		Applications/Databases
 Requires:       %{name}%{?_isa} = %{version}-%{release}
-Provides:	%{sname}-client = %{version}-%{release}
+Provides:	%{sname}%{pg_dotless}-client = %{version}-%{release}
 Provides:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-client = %{version}-%{release}
 Conflicts:	postgis-client
 Conflicts:	postgis%{postgiscurrmajorversion}_%{pg_dotless}-client
@@ -87,7 +87,7 @@ of PostGIS.
 Summary:	Development headers and libraries for PostGIS
 Group:		Development/Libraries
 Requires:       %{name}%{?_isa} = %{version}-%{release}
-Provides:	%{sname}-devel = %{version}-%{release}
+Provides:	%{sname}%{pg_dotless}-devel = %{version}-%{release}
 Provides:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-devel = %{version}-%{release}
 Conflicts:	postgis-devel
 Conflicts:	postgis%{postgiscurrmajorversion}_%{pg_dotless}-devel
@@ -100,6 +100,7 @@ with PostGIS.
 %package docs
 Summary:	Extra documentation for PostGIS
 Group:		Applications/Databases
+Provides:	%{sname}%{pg_dotless}-docs = %{version}-%{release}
 Provides:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-docs = %{version}-%{release}
 Conflicts:	postgis-docs
 Conflicts:	postgis%{postgiscurrmajorversion}_%{pg_dotless}-docs
@@ -113,7 +114,7 @@ Summary:	The utils for PostGIS
 Group:		Applications/Databases
 Requires:	%{name} = %{version}-%{release}
 Requires:	perl-DBD-Pg
-Provides:	%{sname}-utils = %{version}-%{release}
+Provides:	%{sname}%{pg_dotless}-utils = %{version}-%{release}
 Provides:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-utils = %{version}-%{release}
 Conflicts:	postgis-utils
 Conflicts:	postgis%{postgiscurrmajorversion}_%{pg_dotless}-utils

--- a/SPECS/hoot-postgis24.spec
+++ b/SPECS/hoot-postgis24.spec
@@ -57,6 +57,7 @@ Requires:	proj
 Requires:	pcre
 Requires(post):	%{_sbindir}/update-alternatives
 
+Obsoletes:	%{sname}%{postgisprev_dotless}_%{pg_dotless}
 Provides:	%{sname}%{pg_dotless} = %{version}-%{release}
 Provides:	%{sname}%{postgisprev_dotless}_%{pg_dotless} = %{version}-%{release}
 Conflicts:	postgis
@@ -74,6 +75,7 @@ certified as compliant with the "Types and Functions" profile.
 Summary:	Client tools and their libraries of PostGIS
 Group:		Applications/Databases
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+Obsoletes:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-client
 Provides:	%{sname}%{pg_dotless}-client = %{version}-%{release}
 Provides:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-client = %{version}-%{release}
 Conflicts:	postgis-client
@@ -87,6 +89,7 @@ of PostGIS.
 Summary:	Development headers and libraries for PostGIS
 Group:		Development/Libraries
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+Obsoletes:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-devel
 Provides:	%{sname}%{pg_dotless}-devel = %{version}-%{release}
 Provides:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-devel = %{version}-%{release}
 Conflicts:	postgis-devel
@@ -100,6 +103,7 @@ with PostGIS.
 %package docs
 Summary:	Extra documentation for PostGIS
 Group:		Applications/Databases
+Obsoletes:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-docs
 Provides:	%{sname}%{pg_dotless}-docs = %{version}-%{release}
 Provides:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-docs = %{version}-%{release}
 Conflicts:	postgis-docs
@@ -114,6 +118,7 @@ Summary:	The utils for PostGIS
 Group:		Applications/Databases
 Requires:	%{name} = %{version}-%{release}
 Requires:	perl-DBD-Pg
+Obsoletes:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-utils
 Provides:	%{sname}%{pg_dotless}-utils = %{version}-%{release}
 Provides:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-utils = %{version}-%{release}
 Conflicts:	postgis-utils

--- a/SPECS/hoot-postgis24.spec
+++ b/SPECS/hoot-postgis24.spec
@@ -58,7 +58,7 @@ Requires:	pcre
 Requires(post):	%{_sbindir}/update-alternatives
 
 Provides:	%{sname} = %{version}-%{release}
-Obsoletes:	%{sname}%{postgisprev_dotless}_%{pg_dotless}
+Conflicts:	%{sname}%{postgisprev_dotless}_%{pg_dotless}
 Conflicts:	postgis
 Conflicts:	postgis%{postgiscurrmajorversion}_%{pg_dotless}
 
@@ -75,7 +75,7 @@ Summary:	Client tools and their libraries of PostGIS
 Group:		Applications/Databases
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 Provides:	%{sname}-client = %{version}-%{release}
-Obsoletes:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-client
+Conflicts:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-client
 Conflicts:	postgis-client
 Conflicts:	postgis%{postgiscurrmajorversion}_%{pg_dotless}-client
 
@@ -88,7 +88,7 @@ Summary:	Development headers and libraries for PostGIS
 Group:		Development/Libraries
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 Provides:	%{sname}-devel = %{version}-%{release}
-Obsoletes:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-devel
+Conflicts:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-devel
 Conflicts:	postgis-devel
 Conflicts:	postgis%{postgiscurrmajorversion}_%{pg_dotless}-devel
 
@@ -100,7 +100,7 @@ with PostGIS.
 %package docs
 Summary:	Extra documentation for PostGIS
 Group:		Applications/Databases
-Obsoletes:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-docs
+Conflicts:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-docs
 Conflicts:	postgis-docs
 Conflicts:	postgis%{postgiscurrmajorversion}_%{pg_dotless}-docs
 
@@ -114,7 +114,7 @@ Group:		Applications/Databases
 Requires:	%{name} = %{version}-%{release}
 Requires:	perl-DBD-Pg
 Provides:	%{sname}-utils = %{version}-%{release}
-Obsoletes:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-utils
+Conflicts:	%{sname}%{postgisprev_dotless}_%{pg_dotless}-utils
 Conflicts:	postgis-utils
 Conflicts:	postgis%{postgiscurrmajorversion}_%{pg_dotless}-utils
 
@@ -250,5 +250,8 @@ fi
 %doc postgis-%{version}.pdf
 
 %changelog
+* Wed Oct 03 2018 Justin Bronn <justin.bronn@radiantsolutions.com> - 2.4.4-2
+- Fix packaging issues with initial 2.4.4-1 release.
+
 * Mon Sep 24 2018 Justin Bronn <justin.bronn@radiantsolutions.com> - 2.4.4-1
 - Initial release, version 2.4.4.

--- a/SPECS/hoot-postgis24.spec
+++ b/SPECS/hoot-postgis24.spec
@@ -163,8 +163,10 @@ The %{name}-utils package provides the utilities for PostGIS.
 %{__install} -m 0644 utils/*.pl %{buildroot}%{_datadir}/%{name}
 %endif
 
-# Create symlink of .so file. PostGIS hackers said that this is safe:
+# Create symlink of .so files to previous versions. PostGIS hackers said that this is safe:
 %{__ln_s} %{pginstdir}/lib/postgis-%{postgismajorversion}.so %{buildroot}%{pginstdir}/lib/postgis-%{postgisprevmajorversion}.so
+%{__ln_s} %{pginstdir}/lib/postgis_topology-%{postgismajorversion}.so %{buildroot}%{pginstdir}/lib/postgis_topology-%{postgisprevmajorversion}.so
+%{__ln_s} %{pginstdir}/lib/rtpostgis-%{postgismajorversion}.so %{buildroot}%{pginstdir}/lib/rtpostgis-%{postgisprevmajorversion}.so
 
 # Create alternatives entries for common binaries
 %post
@@ -214,6 +216,7 @@ fi
 %{pginstdir}/share/extension/postgis.control
 %{pginstdir}/lib/liblwgeom*.so.*
 %{pginstdir}/lib/postgis_topology-%{postgismajorversion}.so
+%{pginstdir}/lib/postgis_topology-%{postgisprevmajorversion}.so
 %{pginstdir}/lib/address_standardizer-%{postgismajorversion}.so
 %{pginstdir}/lib/liblwgeom.so
 %{pginstdir}/share/extension/address_standardizer*.sql
@@ -225,6 +228,7 @@ fi
 %{pginstdir}/share/contrib/postgis-%{postgismajorversion}/uninstall_legacy.sql
 %{pginstdir}/share/contrib/postgis-%{postgismajorversion}/spatial*.sql
 %{pginstdir}/lib/rtpostgis-%{postgismajorversion}.so
+%{pginstdir}/lib/rtpostgis-%{postgisprevmajorversion}.so
 %{pginstdir}/share/extension/postgis_topology-*.sql
 %{pginstdir}/share/extension/postgis_topology.control
 %{pginstdir}/share/extension/postgis_tiger_geocoder*.sql
@@ -256,7 +260,7 @@ fi
 %doc postgis-%{version}.pdf
 
 %changelog
-* Fri Oct 05 2018 Justin Bronn <justin.bronn@radiantsolutions.com> - 2.4.4-2
+* Mon Oct 08 2018 Justin Bronn <justin.bronn@radiantsolutions.com> - 2.4.4-2
 - Fix packaging issues in initial release.
 
 * Mon Sep 24 2018 Justin Bronn <justin.bronn@radiantsolutions.com> - 2.4.4-1

--- a/config.yml
+++ b/config.yml
@@ -11,7 +11,7 @@ versions:
   mocha: &mocha_version '3.5.3'
   nodejs: &nodejs_version '8.9.3-1'
   osmosis: &osmosis_version '0.46-1'
-  postgis: &postgis_version '2.4.4-1'
+  postgis: &postgis_version '2.4.4-2'
   postgresql: &pg_version '9.5'
   stxxl: &stxxl_version '1.3.1-1'
   su-exec: &suexec_version '0.2-1'


### PR DESCRIPTION
This fixes some packaging issues with the PostGIS 2.4.4-1 release, most importantly fixing to allow the latest Hootenanny release to install again.  Specifically, `hootenanny-services-ui` had a hard dependency on the `hoot-postgis23_95` package, which was obsoleted by the 2.4.4-1 release with #230.  The key was to have the `hoot-postgis24_95` package also *provide* the capabilities of the `hoot-postgis23_95` package it obsoletes, allowing the old Hootenanny releases to resolve the dependencies again.

In addition, previous version symlinks for the raster and topology shared libraries were added to smooth over compatibility issues for existing PostGIS 2.3 databases.  Prior to this, using some spatial functions could cause errors:

```
wfsstoredb=# SELECT postgis_full_version();
ERROR:  could not access file "$libdir/rtpostgis-2.3": No such file or directory
CONTEXT:  SQL statement "SELECT postgis_gdal_version()"
PL/pgSQL function postgis_full_version() line 27 at SQL statement
```

While this could be fixed with an [`ALTER EXTENSION postgis UPDATE TO "2.4.4"`](http://postgis.net/docs/manual-2.4/postgis_installation.html#upgrading) statement, it was annoying.  With the symlinks, things work better:

```
wfsstoredb=# SELECT postgis_full_version();
                                                                                                                        postgis_full_version                                                                
                                                        
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------------
 POSTGIS="2.4.4 r16526" GEOS="3.6.2-CAPI-1.10.2 4d2925d6" PROJ="Rel. 4.8.0, 6 March 2012" GDAL="GDAL 2.1.4, released 2017/06/23" LIBXML="2.9.1" LIBJSON="0.11" (core procs from "2.3.5 r16110" need upgrade)
 RASTER (raster procs from "2.3.5 r16110" need upgrade)
(1 row)
```

The updated and signed dependencies live at:
https://s3.amazonaws.com/hoot-repo/el7/deps/postgis-hotfix.  This will be renamed to `release` once this PR is approved.

Other changes:
* Now provide `hoot-postgis95` instead of for `hoot-postgis`; unfortunately, specifying PostgreSQL version string is necessary to differentiate packages.
* Fix minor nits with spacing and octal modes.