### PR TITLE
Include Hootenanny UI 2.0 Files

### DIFF
--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -26,8 +26,9 @@
 %global hoot_version_tag %(echo %{hoot_version_gen} | %{__awk} -F_ '{ print $1 }')
 %global hoot_extra_version %(echo %{hoot_version_gen} | %{__awk} -F_ '{ print $2 }')
 
-# The NodeJS Mapnik service is disabled until it can be fixed.
-%global with_node_mapnik 0
+# Disable NodeJS Mapnik service is until fixed.
+%bcond_with node_mapnik
+
 
 %if 0%{hoot_extra_version} == 0
   # If this is a tagged release, then we want the RPM release to be
@@ -180,7 +181,7 @@ pushd node-export-server
 npm install --production
 popd
 
-%if 0%{with_node_mapnik} == 1
+%if %{with node_mapnik}
 pushd node-mapnik-server
 npm install --production
 popd
@@ -253,7 +254,7 @@ Restart=on-abort
 WantedBy=multi-user.target
 EOF
 
-%if 0%{with_node_mapnik} == 1
+%if %{with node_mapnik}
 # node-mapnik
 %{__install} -d -m 0775 %{buildroot}%{hoot_home}/node-mapnik-server
 %{__cp} -p node-mapnik-server/*.{js,json,xml,svg} %{buildroot}%{hoot_home}/node-mapnik-server
@@ -365,13 +366,13 @@ This package contains the UI and web services.
 
 %files services-ui
 %{_unitdir}/node-export.service
-%if 0%{with_node_mapnik} == 1
+%if %{with node_mapnik}
 %{_unitdir}/node-mapnik.service
 %endif
 
 %defattr(-, root, tomcat, 0775)
 %{hoot_home}/node-export-server
-%if 0%{with_node_mapnik} == 1
+%if %{with node_mapnik}
 %{hoot_home}/node-mapnik-server
 %endif
 %{hoot_home}/test-files
@@ -410,7 +411,7 @@ fi
 %preun services-ui
 
 %systemd_preun node-export.service
-%if 0%{with_node_mapnik} == 1
+%if %{with node_mapnik}
 %systemd_preun node-mapnik.service
 %endif
 
@@ -419,7 +420,7 @@ fi
 if test -f /.dockerenv; then exit 0; fi
 
 %systemd_post node-export.service
-%if 0%{with_node_mapnik} == 1
+%if %{with node_mapnik}
 %systemd_post node-mapnik.service
 %endif
 
@@ -592,7 +593,7 @@ EOT
     rm -f /tmp/osmapidb.log
 
     systemctl start node-export.service
-%if 0%{with_node_mapnik} == 1
+%if %{with node_mapnik}
     systemctl start node-mapnik.service
 %endif
 
@@ -624,7 +625,7 @@ fi
 if test -f /.dockerenv; then exit 0; fi
 
 %systemd_postun node-export.service
-%if 0%{with_node_mapnik} == 1
+%if %{with node_mapnik}
 %systemd_postun node-mapnik.service
 %endif
 
@@ -686,7 +687,7 @@ if [ "$1" = "1" ]; then
     systemctl enable tomcat8
     # set NodeJS node-export-server to autostart
     systemctl enable node-export
-%if 0%{with_node_mapnik} == 1
+%if %{with node_mapnik}
     # set NodeJS node-mapnik-server to autostart
     systemctl enable node-mapnik
 %endif
@@ -705,7 +706,7 @@ if [ "$1" = "0" ]; then
     systemctl disable tomcat8
     # set NodeJS node-export-server to NOT autostart
     systemctl disable node-export
-%if 0%{with_node_mapnik} == 1
+%if %{with node_mapnik}
     # set NodeJS node-mapnik-server to NOT autostart
     systemctl disable node-mapnik
 %endif

--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -29,6 +29,8 @@
 # Disable NodeJS Mapnik service is until fixed.
 %bcond_with node_mapnik
 
+# Conditional for including Hootenanny 2.x files while separat.e
+%bcond_without hoot_ui2
 
 %if 0%{hoot_extra_version} == 0
   # If this is a tagged release, then we want the RPM release to be
@@ -215,6 +217,14 @@ popd
 %{__cp} -pr hoot-ui/dist/* %{buildroot}%{tomcat_webapps}/%{name}-id/
 %{__install} -m 0644 hoot-ui/data/osm-plus-taginfo.csv %{buildroot}%{tomcat_webapps}/%{name}-id/data
 %{__install} -m 0644 hoot-ui/data/tdsv61_field_values.json %{buildroot}%{tomcat_webapps}/%{name}-id/data
+%if %{with hoot_ui2}
+# Hootenanny UI 2.x files.
+%{__install} -d -m 0775 %{buildroot}%{tomcat_webapps}/%{name}-id2x
+%{__install} -d -m 0775 %{buildroot}%{tomcat_webapps}/%{name}-id2x/data
+%{__cp} -pr hoot-ui-2x/dist/* %{buildroot}%{tomcat_webapps}/%{name}-id2x/
+%{__install} -m 0644 hoot-ui/data/osm-plus-taginfo.csv %{buildroot}%{tomcat_webapps}/%{name}-id2x/data
+%{__install} -m 0644 hoot-ui/data/tdsv61_field_values.json %{buildroot}%{tomcat_webapps}/%{name}-id2x/data
+%endif
 
 # Tomcat environment settings for Hootenanny.
 %{__cat} >> %{buildroot}%{tomcat_config}/conf.d/hoot.conf << EOF
@@ -380,6 +390,9 @@ This package contains the UI and web services.
 %{tomcat_config}/conf.d/hoot.conf
 %{tomcat_webapps}/hoot-services.war
 %{tomcat_webapps}/%{name}-id
+%if %{with hoot_ui2}
+%{tomcat_webapps}/%{name}-id2x
+%endif
 
 %defattr(-, tomcat, tomcat, 0775)
 %{hoot_home}/tmp

--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -26,7 +26,7 @@
 %global hoot_version_tag %(echo %{hoot_version_gen} | %{__awk} -F_ '{ print $1 }')
 %global hoot_extra_version %(echo %{hoot_version_gen} | %{__awk} -F_ '{ print $2 }')
 
-# Disable NodeJS Mapnik service is until fixed.
+# Disable NodeJS Mapnik service until fixed in Hootenanny.
 %bcond_with node_mapnik
 
 # Include Hootenanny 2.x files by default.

--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -29,7 +29,7 @@
 # Disable NodeJS Mapnik service is until fixed.
 %bcond_with node_mapnik
 
-# Conditional for including Hootenanny 2.x files while separat.e
+# Include Hootenanny 2.x files by default.
 %bcond_without hoot_ui2
 
 %if 0%{hoot_extra_version} == 0

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -247,6 +247,17 @@ def rpmbuild(config, name, options)
         rpmbuild_cmd << macro
       end
 
+      # Set any with/without options.
+      options.fetch('with', []).each do |with_option|
+        rpmbuild_cmd << '--with'
+        rpmbuild_cmd << with_option
+      end
+
+      options.fetch('without', []).each do |without_option|
+        rpmbuild_cmd << '--without'
+        rpmbuild_cmd << without_option
+      end
+
       # Default to using `rpmbuild -bb`.
       rpmbuild_cmd << options.fetch('build_type', '-bb')
       rpmbuild_cmd << options.fetch('spec_file', "SPECS/#{name}.spec")

--- a/scripts/hoot-checkout.sh
+++ b/scripts/hoot-checkout.sh
@@ -15,14 +15,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 set -euo pipefail
 GIT_COMMIT="${1:-develop}"
-HOOT_DEST=${HOOT_DEST:-$HOME/hootenanny}
-HOOT_REPO=${HOOT_REPO:-https://github.com/ngageoint/hootenanny.git}
+HOOT_DEST="${HOOT_DEST:-$HOME/hootenanny}"
+HOOT_REPO="${HOOT_REPO:-https://github.com/ngageoint/hootenanny.git}"
 
-if [ ! -d $HOOT_DEST/.git ]; then
-    git clone $HOOT_REPO $HOOT_DEST
+if [ ! -d "$HOOT_DEST/.git" ]; then
+    git clone "$HOOT_REPO" "$HOOT_DEST"
 fi
 
-pushd $HOOT_DEST
+pushd "$HOOT_DEST"
 # Clean out any untracked files.
 git clean -q -f -d -x
 
@@ -30,7 +30,7 @@ git clean -q -f -d -x
 git fetch --tags
 
 # Checkout desired commit; pull latest when on a branch.
-git checkout $GIT_COMMIT
+git checkout "$GIT_COMMIT"
 if git symbolic-ref --short HEAD; then
     git pull
 fi

--- a/scripts/nodejs-install.sh
+++ b/scripts/nodejs-install.sh
@@ -16,11 +16,11 @@
 set -euo pipefail
 
 # Ensure the release is stripped from version.
-NODE_VERSION=$(echo $1 | awk -F- '{ print $1 }')
+NODE_VERSION="$(echo "$1" | awk -F- '{ print $1 }')"
 
 # Install the specific version of NodeJS and the yum version locking plugin.
 yum install -q -y \
-    nodejs-$NODE_VERSION nodejs-devel-$NODE_VERSION \
+    "nodejs-$NODE_VERSION" "nodejs-devel-$NODE_VERSION" \
     yum-plugin-versionlock
 
 # Version lock the NodeJS version to prevent inadvertent upgrades.

--- a/scripts/nodesource-repo.sh
+++ b/scripts/nodesource-repo.sh
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 set -euo pipefail
 
-NODE_VERSION=$1
-NODESOURCE_DIR=$(echo $NODE_VERSION | awk -F. '{ if ($1 == "0") { print "pub_" $1 "." $2 } else { print "pub_" $1 ".x" } }')
-NODESOURCE_BASEURL=${NODESOURCE_BASEURL:-https://rpm.nodesource.com/$NODESOURCE_DIR/el}
+NODE_VERSION="$1"
+NODESOURCE_DIR="$(echo "$NODE_VERSION" | awk -F. '{ if ($1 == "0") { print "pub_" $1 "." $2 } else { print "pub_" $1 ".x" } }')"
+NODESOURCE_BASEURL="${NODESOURCE_BASEURL:-https://rpm.nodesource.com/$NODESOURCE_DIR/el}"
 NODESOURCE_KEY=/etc/pki/rpm-gpg/NODESOURCE-GPG-SIGNING-KEY-EL
 
 cat > $NODESOURCE_KEY <<EOF

--- a/tests/lint-bash.sh
+++ b/tests/lint-bash.sh
@@ -24,8 +24,11 @@ fi
 shellcheck \
     scripts/docker-install.sh \
     scripts/hoot-archive.sh \
+    scripts/hoot-checkout.sh \
     scripts/hoot-repo.sh \
     scripts/latest-archive.sh \
+    scripts/nodejs-install.sh \
+    scripts/nodesource-repo.sh \
     scripts/query-archive.sh \
     scripts/repo-sync.sh \
     scripts/repo-update.sh \
@@ -38,9 +41,6 @@ shellcheck \
 # Scripts with *only* quoting errors.
 shellcheck \
     --exclude SC2086 \
-    scripts/hoot-checkout.sh \
-    scripts/nodejs-install.sh \
-    scripts/nodesource-repo.sh \
     scripts/pgdg-repo.sh \
     scripts/postgresql-install.sh \
     scripts/repo-sign.sh \


### PR DESCRIPTION
This PR includes the Hootenanny UI 2.0 files in the RPM, available at `/hootenanny-id2x`.  This adds a binary condition, `hoot_ui2`, set by default to `hootenanny.spec`.

The following minor changes are also included:
* `node_mapnik` binary condition now used (unset by default) instead of `with_node_mapnik` global
* Can add `with` / `without` settings to `config.yml` for use in building RPMs.
* Fix quoting in a few shell scripts to be up to `shellcheck`'s standards.