### PR TITLE
Upgrade to Vagrant 2.2.0.

### DIFF
--- a/scripts/vagrant-install.sh
+++ b/scripts/vagrant-install.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 #  * VAGRANT_VERSION
 #  * VAGRANT_BASEURL
 LSB_DIST="$(. /etc/os-release && echo "$ID")"
-VAGRANT_VERSION="${VAGRANT_VERSION:-2.1.4}"
+VAGRANT_VERSION="${VAGRANT_VERSION:-2.2.0}"
 VAGRANT_BASEURL="${VAGRANT_BASEURL:-https://releases.hashicorp.com/vagrant/$VAGRANT_VERSION}"
 
 # Set up command differences between RHEL and Debian-based systems.


### PR DESCRIPTION
Use Vagrant 2.2.0, released 10/16/2018.