### PR TITLE
Maven Cache Refresh

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -24,8 +24,8 @@ versions:
 
 
 maven:
-  cache_url: &maven_cache_url 'https://s3.amazonaws.com/hoot-maven/m2-cache-2018-10-02.tar.gz'
-  cache_sha1: &maven_cache_sha1 '139706efd58685866ea2341d82fef1153785a84c'
+  cache_url: &maven_cache_url 'https://s3.amazonaws.com/hoot-maven/m2-cache-2018-12-06.tar.gz'
+  cache_sha1: &maven_cache_sha1 'c6e87f8100c9461c00b7d28a5a8d0e8b1737ccf3'
 
 
 rpmbuild:


### PR DESCRIPTION
This updates the Maven cache for the latest in develop ([ngageoint/hootenanny@8e02eb2](https://github.com/ngageoint/hootenanny/blob/8e02eb2a4dc9a180e7bca62645b88f0da7371c0a/hoot-services/pom.xml)).  Here's a [difference from the `m2-cache-2018-10-02.tar.gz` archive](https://gist.github.com/jbronn/10a82638fb5722ef7f5221fea669b60a) for further reference.