### PR TITLE
libpng required

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   lint:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/rpmbuild-lint@sha256:5b33ea61e06b12f6b33fad46a9d17613aa19a025d36de8e78719acb6b4dc6726
+      - image: hootenanny/rpmbuild-lint@sha256:1e39dea036ffe7bb43e3c2279d91ec473891fa55e7aad53a448e61b467d46e32
         user: rpmbuild
     steps:
       - checkout
@@ -52,7 +52,7 @@ jobs:
   develop-install:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/run-base-release@sha256:3d322410c3e0723e8a90044ad31e69daa24606bbca5efa5365ff228e33f441f5
+      - image: hootenanny/run-base-release@sha256:78dff0ce8834c8478aad2442907b59ea6a7d3327126498ead55b714e5a318c5f
     steps:
       - checkout
       - attach_workspace:
@@ -64,7 +64,7 @@ jobs:
   develop-upgrade:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/run-base-release@sha256:3d322410c3e0723e8a90044ad31e69daa24606bbca5efa5365ff228e33f441f5
+      - image: hootenanny/run-base-release@sha256:78dff0ce8834c8478aad2442907b59ea6a7d3327126498ead55b714e5a318c5f
     steps:
       - checkout
       - attach_workspace:
@@ -76,7 +76,7 @@ jobs:
   develop-sync:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/rpmbuild-repo@sha256:199d872d842961003769f1f589c72097ce9ed21572c5664071b599c838224f88
+      - image: hootenanny/rpmbuild-repo@sha256:d312a17e5e4f885ae6c575efe05356a818737dda6d40ac5316ee633077a1cc23
         user: rpmbuild
     steps:
       - checkout

--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -105,6 +105,7 @@ BuildRequires:  java-1.8.0-openjdk
 BuildRequires:  libicu-devel
 BuildRequires:  liboauthcpp-devel
 BuildRequires:  libphonenumber-devel
+BuildRequires:  libpng-devel
 BuildRequires:  libpostal-devel
 BuildRequires:  libxslt
 BuildRequires:  log4cxx-devel

--- a/scripts/vagrant-install.sh
+++ b/scripts/vagrant-install.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 #  * VAGRANT_VERSION
 #  * VAGRANT_BASEURL
 LSB_DIST="$(. /etc/os-release && echo "$ID")"
-VAGRANT_VERSION="${VAGRANT_VERSION:-2.2.2}"
+VAGRANT_VERSION="${VAGRANT_VERSION:-2.2.3}"
 VAGRANT_BASEURL="${VAGRANT_BASEURL:-https://releases.hashicorp.com/vagrant/$VAGRANT_VERSION}"
 
 # Set up command differences between RHEL and Debian-based systems.

--- a/scripts/vagrant-install.sh
+++ b/scripts/vagrant-install.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 #  * VAGRANT_VERSION
 #  * VAGRANT_BASEURL
 LSB_DIST="$(. /etc/os-release && echo "$ID")"
-VAGRANT_VERSION="${VAGRANT_VERSION:-2.2.0}"
+VAGRANT_VERSION="${VAGRANT_VERSION:-2.2.2}"
 VAGRANT_BASEURL="${VAGRANT_BASEURL:-https://releases.hashicorp.com/vagrant/$VAGRANT_VERSION}"
 
 # Set up command differences between RHEL and Debian-based systems.


### PR DESCRIPTION
This PR adds `libpng-devel` to the packages required to build Hootenanny, necessary from changes introduced with ngageoint/hootenanny#2829.  I then pushed up container images with the new dependency, which should fix our `develop` RPM workflow.