### PR TITLE
Upgrade to Qt5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   lint:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/rpmbuild-lint@sha256:1e39dea036ffe7bb43e3c2279d91ec473891fa55e7aad53a448e61b467d46e32
+      - image: hootenanny/rpmbuild-lint@sha256:65b352fe7530be8ae7adeaa8e0d1d6e1055ccae63683e256f263de3139c4977b
         user: rpmbuild
     steps:
       - checkout
@@ -52,7 +52,7 @@ jobs:
   develop-install:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/run-base-release@sha256:78dff0ce8834c8478aad2442907b59ea6a7d3327126498ead55b714e5a318c5f
+      - image: hootenanny/run-base-release@sha256:9c338405145123af19073350579d3bc4f3dc32d821f670740ff6361b37d60a93
     steps:
       - checkout
       - attach_workspace:
@@ -64,7 +64,7 @@ jobs:
   develop-upgrade:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/run-base-release@sha256:78dff0ce8834c8478aad2442907b59ea6a7d3327126498ead55b714e5a318c5f
+      - image: hootenanny/run-base-release@sha256:9c338405145123af19073350579d3bc4f3dc32d821f670740ff6361b37d60a93
     steps:
       - checkout
       - attach_workspace:
@@ -76,7 +76,7 @@ jobs:
   develop-sync:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/rpmbuild-repo@sha256:d312a17e5e4f885ae6c575efe05356a818737dda6d40ac5316ee633077a1cc23
+      - image: hootenanny/rpmbuild-repo@sha256:95765e70b5cc1036885443e085771e7a9973df3c4a6388013bbdf0e3bb1df0ae
         user: rpmbuild
     steps:
       - checkout

--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -117,8 +117,8 @@ BuildRequires:  proj-devel
 BuildRequires:  protobuf-devel
 BuildRequires:  python-argparse
 BuildRequires:  python-devel
-BuildRequires:  qt-devel
-BuildRequires:  qt-postgresql
+BuildRequires:  qt5-qtbase-devel
+BuildRequires:  qt5-qtbase-postgresql
 BuildRequires:  stxxl-devel
 BuildRequires:  texlive
 BuildRequires:  texlive-collection-fontsrecommended


### PR DESCRIPTION
Fixes #252.  Uses Qt5 instead of Qt4 in the build images.  *Do not merge* until ngageoint/hootenanny#3035 is complete, otherwise our RPM builds will fail due to Qt conflicts.