### PR TITLE
ccache

### DIFF
--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -85,6 +85,7 @@ BuildRequires:  autoconf
 BuildRequires:  autoconf-archive
 BuildRequires:  automake
 BuildRequires:  boost-devel
+BuildRequires:  ccache
 BuildRequires:  cppunit-devel
 BuildRequires:  dblatex
 BuildRequires:  doxygen


### PR DESCRIPTION
This adds the `ccache` requirement to Hootenanny's build images, which I'll update once this is merged.