### PR TITLE
Remove logc4xx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   lint:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/rpmbuild-lint@sha256:1e7018346b8e364d7cb085531bb6196b6b3efbcf3d93b4f1cf0ffbc0cae0405d
+      - image: hootenanny/rpmbuild-lint@sha256:49adbc6c771c0e2cb14b302e4204cf7d3207f4ef7dee0ef12461ceaafff4725a
         user: rpmbuild
     steps:
       - checkout
@@ -52,7 +52,7 @@ jobs:
   develop-install:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/run-base-release@sha256:f5e356452e887e82bb8dac3156b61f143443bcdac608988ccc42a92771f54b27
+      - image: hootenanny/run-base-release@sha256:a4fba00ec4998948024e8b51e7da0d87ad197f4de0589ffb59f9293e0896bc38
     steps:
       - checkout
       - attach_workspace:
@@ -64,7 +64,7 @@ jobs:
   develop-upgrade:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/run-base-release@sha256:f5e356452e887e82bb8dac3156b61f143443bcdac608988ccc42a92771f54b27
+      - image: hootenanny/run-base-release@sha256:a4fba00ec4998948024e8b51e7da0d87ad197f4de0589ffb59f9293e0896bc38
     steps:
       - checkout
       - attach_workspace:
@@ -76,7 +76,7 @@ jobs:
   develop-sync:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/rpmbuild-repo@sha256:3188fdacecb7ae5659e0274828b66da4b000f37357ad6bd71478a82137c35eea
+      - image: hootenanny/rpmbuild-repo@sha256:317f1df99e5cacf0575644cad1956ddfcfc562c5198f1d8590afa5db33d7e057
         user: rpmbuild
     steps:
       - checkout

--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -109,7 +109,6 @@ BuildRequires:  libphonenumber-devel
 BuildRequires:  libpng-devel
 BuildRequires:  libpostal-devel
 BuildRequires:  libxslt
-BuildRequires:  log4cxx-devel
 BuildRequires:  maven
 BuildRequires:  nodejs-devel
 BuildRequires:  opencv-devel
@@ -807,7 +806,6 @@ Requires:  git
 Requires:  glpk-devel = %{glpk_version}
 Requires:  hoot-words
 Requires:  libicu-devel
-Requires:  log4cxx-devel
 Requires:  nodejs-devel = %{nodejs_epoch}:%{nodejs_version}
 Requires:  opencv-devel
 Requires:  postgresql%{pg_dotless}-devel
@@ -861,7 +859,6 @@ Requires:  liboauthcpp = %{liboauthcpp_version}
 Requires:  libphonenumber = %{libphonenumber_version}
 Requires:  libpostal
 Requires:  libpostal-data
-Requires:  log4cxx
 Requires:  nodejs = %{nodejs_epoch}:%{nodejs_version}
 Requires:  opencv
 Requires:  postgresql%{pg_dotless}-libs


### PR DESCRIPTION
Fixes #264: remove `logc4xx` and `logc4xx-devel` from RPM requirements and update hashes to latest Docker images.