### PR TITLE
Remove PostGIS dependency and WFS References

### DIFF
--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -99,8 +99,6 @@ BuildRequires:  graphviz
 BuildRequires:  hoot-gdal
 BuildRequires:  hoot-gdal-devel
 BuildRequires:  hoot-gdal-python
-BuildRequires:  hoot-postgis24_%{pg_dotless}-devel
-BuildRequires:  hoot-postgis24_%{pg_dotless}-utils
 BuildRequires:  hoot-words
 BuildRequires:  java-1.8.0-openjdk
 BuildRequires:  libicu-devel
@@ -340,7 +338,6 @@ echo "export HOOT_HOME=%{hoot_home}" > %{buildroot}%{_sysconfdir}/profile.d/hoot
 Summary:   Hootenanny UI and Services
 Group:     Applications/Engineering
 Requires:  %{name}-core = %{version}-%{release}
-Requires:  hoot-postgis24_%{pg_dotless}
 Requires:  java-1.8.0-openjdk
 Requires:  liquibase
 Requires:  osmosis
@@ -540,10 +537,7 @@ if [ "$1" = "1" ]; then
             sed -i s/DB_PASSWORD=.*/DB_PASSWORD=$RAND_PW/ %{hoot_home}/conf/database/DatabaseConfig.sh
         fi
         su -l postgres -c "createdb hoot --owner=hoot"
-        su -l postgres -c "createdb wfsstoredb --owner=hoot"
         su -l postgres -c "psql -d hoot -c \"CREATE EXTENSION hstore;\""
-        su -l postgres -c "psql -d wfsstoredb -c \"CREATE EXTENSION postgis; GRANT ALL ON geography_columns, geometry_columns, spatial_ref_sys TO PUBLIC;\""
-        su -l postgres -c "psql -d postgres -c \"UPDATE pg_database SET datistemplate='true' WHERE datname='wfsstoredb';\""
     fi
 
     # restore saved db config file settings if present
@@ -698,8 +692,6 @@ Summary:   Development dependencies for Hootenanny Services
 Group:     Development/Libraries
 BuildArch: noarch
 Requires:  %{name}-core-devel-deps = %{version}-%{release}
-Requires:  hoot-postgis24_%{pg_dotless}
-Requires:  hoot-postgis24_%{pg_dotless}-utils
 Requires:  liquibase
 Requires:  maven
 Requires:  nodejs-devel = %{nodejs_epoch}:%{nodejs_version}
@@ -753,10 +745,7 @@ if [ "$1" = "1" ]; then
         su -l postgres -c "createuser --superuser hoot || true"
         su -l postgres -c "psql -c \"ALTER USER hoot WITH PASSWORD 'hoottest';\""
         su -l postgres -c "createdb hoot --owner=hoot"
-        su -l postgres -c "createdb wfsstoredb --owner=hoot"
         su -l postgres -c "psql -d hoot -c \"CREATE EXTENSION hstore;\""
-        su -l postgres -c "psql -d wfsstoredb -c \"CREATE EXTENSION postgis; GRANT ALL ON geography_columns, geometry_columns, spatial_ref_sys TO PUBLIC;\""
-        su -l postgres -c "psql -d postgres -c \"UPDATE pg_database SET datistemplate='true' WHERE datname='wfsstoredb'\";"
     fi
 
     # configure Postgres settings

--- a/config.yml
+++ b/config.yml
@@ -125,7 +125,6 @@ images:
           nodejs_version: *nodejs_version
           osmosis_version: *osmosis_version
           pg_version: *pg_version
-          postgis_version: *postgis_version
           stxxl_version: *stxxl_version
           suexec_version: *suexec_version
           tomcat8_version: *tomcat8_version
@@ -146,7 +145,6 @@ images:
           nodejs_version: *nodejs_version
           osmosis_version: *osmosis_version
           pg_version: *pg_version
-          postgis_version: *postgis_version
           stxxl_version: *stxxl_version
           suexec_version: *suexec_version
           tomcat8_version: *tomcat8_version

--- a/docker/Dockerfile.rpmbuild-hoot-devel
+++ b/docker/Dockerfile.rpmbuild-hoot-devel
@@ -1,3 +1,4 @@
+# Copyright (C) 2019 Maxar Technologies (https://www.maxar.com)
 # Copyright (C) 2018 Radiant Solutions (http://www.radiantsolutions.com)
 #
 # This program is free software: you can redistribute it and/or modify
@@ -37,7 +38,6 @@ ARG mocha_version
 ARG nodejs_version
 ARG osmosis_version
 ARG packages
-ARG postgis_version
 ARG pg_version
 ARG pg_data=/var/lib/pgsql/${pg_version}/data
 ARG stxxl_version
@@ -62,9 +62,6 @@ COPY RPMS/x86_64/dumb-init-${dumbinit_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/hoot-gdal-devel-${gdal_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/hoot-gdal-libs-${gdal_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/hoot-gdal-python-${gdal_version}${RPMBUILD_DIST}.x86_64.rpm \
-     RPMS/x86_64/hoot-postgis24_95-${postgis_version}${RPMBUILD_DIST}.x86_64.rpm \
-     RPMS/x86_64/hoot-postgis24_95-devel-${postgis_version}${RPMBUILD_DIST}.x86_64.rpm \
-     RPMS/x86_64/hoot-postgis24_95-utils-${postgis_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/noarch/hoot-words-${words_version}${RPMBUILD_DIST}.noarch.rpm \
      RPMS/x86_64/libgeotiff-${libgeotiff_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/libgeotiff-devel-${libgeotiff_version}${RPMBUILD_DIST}.x86_64.rpm \
@@ -97,9 +94,6 @@ RUN yum install -y \
     /tmp/hoot-gdal-devel-${gdal_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/hoot-gdal-libs-${gdal_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/hoot-gdal-python-${gdal_version}${RPMBUILD_DIST}.x86_64.rpm \
-    /tmp/hoot-postgis24_95-${postgis_version}${RPMBUILD_DIST}.x86_64.rpm \
-    /tmp/hoot-postgis24_95-devel-${postgis_version}${RPMBUILD_DIST}.x86_64.rpm \
-    /tmp/hoot-postgis24_95-utils-${postgis_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/hoot-words-${words_version}${RPMBUILD_DIST}.noarch.rpm \
     /tmp/libgeotiff-${libgeotiff_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/libgeotiff-devel-${libgeotiff_version}${RPMBUILD_DIST}.x86_64.rpm \

--- a/docker/Dockerfile.run-base-devel
+++ b/docker/Dockerfile.run-base-devel
@@ -1,3 +1,4 @@
+# Copyright (C) 2019 Maxar Technologies (https://www.maxar.com)
 # Copyright (C) 2018 Radiant Solutions (http://www.radiantsolutions.com)
 #
 # This program is free software: you can redistribute it and/or modify
@@ -30,7 +31,6 @@ ARG libkml_version
 ARG mocha_version
 ARG nodejs_version
 ARG osmosis_version
-ARG postgis_version
 ARG pg_version
 ARG rpmbuild_dist=.el7
 ARG stxxl_version
@@ -48,8 +48,6 @@ COPY RPMS/x86_64/dumb-init-${dumbinit_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/hoot-gdal-devel-${gdal_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/hoot-gdal-libs-${gdal_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/hoot-gdal-python-${gdal_version}${RPMBUILD_DIST}.x86_64.rpm \
-     RPMS/x86_64/hoot-postgis24_95-${postgis_version}${RPMBUILD_DIST}.x86_64.rpm \
-     RPMS/x86_64/hoot-postgis24_95-utils-${postgis_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/noarch/hoot-words-${words_version}${RPMBUILD_DIST}.noarch.rpm \
      RPMS/x86_64/libgeotiff-${libgeotiff_version}${RPMBUILD_DIST}.x86_64.rpm \
      RPMS/x86_64/libkml-${libkml_version}${RPMBUILD_DIST}.x86_64.rpm \
@@ -69,8 +67,6 @@ RUN yum install -y \
     /tmp/hoot-gdal-devel-${gdal_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/hoot-gdal-libs-${gdal_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/hoot-gdal-python-${gdal_version}${RPMBUILD_DIST}.x86_64.rpm \
-    /tmp/hoot-postgis24_95-${postgis_version}${RPMBUILD_DIST}.x86_64.rpm \
-    /tmp/hoot-postgis24_95-utils-${postgis_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/hoot-words-${words_version}${RPMBUILD_DIST}.noarch.rpm \
     /tmp/libgeotiff-${libgeotiff_version}${RPMBUILD_DIST}.x86_64.rpm \
     /tmp/libkml-${libkml_version}${RPMBUILD_DIST}.x86_64.rpm \

--- a/scripts/hoot-db-setup.sh
+++ b/scripts/hoot-db-setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (C) 2019 Maxar Technologies (https://www.maxar.com)
 # Copyright (C) 2018 Radiant Solutions (http://www.radiantsolutions.com)
 #
 # This program is free software: you can redistribute it and/or modify
@@ -24,7 +25,6 @@ DB_NAME="${DB_NAME:-hoot}"
 DB_NAME_OSMAPI="${DB_NAME_OSMAPI:-osmapi_test}"
 DB_USER="${DB_USER:-hoot}"
 DB_PASSWORD="${DB_PASSWORD:-hoottest}"
-WFS_DB_NAME="${WFS_DB_NAME:-wfsstoredb}"
 
 sed -i s/^max_connections/\#max_connections/ $POSTGRES_CONF
 sed -i s/^shared_buffers/\#shared_buffers/ $POSTGRES_CONF
@@ -60,13 +60,6 @@ psql --username postgres --dbname postgres --command \
 createdb --username postgres $DB_NAME --owner $DB_USER
 psql --username postgres --dbname $DB_NAME --command \
      "CREATE EXTENSION hstore;"
-
-# Create hoot WFS database template, with PostGIS.
-createdb --username postgres $WFS_DB_NAME --owner $DB_USER
-psql --username postgres --dbname $WFS_DB_NAME --command \
-     "CREATE EXTENSION postgis; GRANT ALL ON geography_columns, geometry_columns, spatial_ref_sys TO PUBLIC;"
-psql --username postgres --dbname postgres --command \
-     "UPDATE pg_database SET datistemplate='true' WHERE datname='${WFS_DB_NAME}';"
 
 # Stop database.
 su-exec postgres pg_ctl -D $PGDATA -s -m fast -w stop


### PR DESCRIPTION
Fixes #228; companion to ngageoint/hootenanny#3319.   Removes PostGIS as a buildtime and runtime requirement of the Hootenanny RPM.   Further removal of source archives, spec files, and Docker files will be handled in #277.