### PR TITLE
dumb-init 1.2.2

### DIFF
--- a/SPECS/dumb-init.spec
+++ b/SPECS/dumb-init.spec
@@ -1,3 +1,4 @@
+# Copyright (C) 2019 Maxar Technologies (https://www.maxar.com)
 # Copyright (C) 2018 Radiant Solutions (http://www.radiantsolutions.com)
 #
 # This program is free software: you can redistribute it and/or modify
@@ -16,33 +17,34 @@ Name:		dumb-init
 Version:	%{rpmbuild_version}
 Release:	%{rpmbuild_release}%{?dist}
 Summary:	Simple process supervisor and init system for containers
-Group:		Applications/System
 License:	MIT
 URL:		https://github.com/Yelp/dumb-init
 Source0:	https://github.com/Yelp/dumb-init/archive/v%{version}/dumb-init-%{version}.tar.gz
 
 %description
-dumb-init is a simple process supervisor that forwards signals to children.
-It is designed to run as PID1 in minimal container environments.
+dumb-init is a simple process supervisor that forwards signals to children,
+and designed to run as PID 1 in minimal container environments.
 
 %prep
 %setup -q
 
 %build
-# Remove static compilation flag, as we're only targeting Enterprise Linux
-# containers (like the rest of our dependencies).
-%{__sed} -i -e 's/ -static//' Makefile
-%{__make}
-
-# TODO: Consider substituting hard-coded CFLAGS with `%{optflags}` in Makefile.
+# Allow overriding of the CFLAGS environment variable so we can use
+# standard compilation options (including hardening).
+%{__sed} -i -e 's/^CFLAGS=/CFLAGS\ \?=\ /' Makefile
+CFLAGS="%{optflags}" %make_build
 
 %install
 # Placing in binary directory as it may be invoked by non-root users.
 %{__install} -p -D -m 0755 dumb-init %{buildroot}%{_bindir}/dumb-init
 
 %files
+%doc CONTRIBUTING.md README.md
+%license LICENSE
 %{_bindir}/dumb-init
 
 %changelog
+* Fri Jul 19 2019 Justin Bronn <justin.bronn@maxar.com> 1.2.2-1
+- Upgrade to 1.2.2.
 * Tue Jan 16 2018 Justin Bronn <justin.bronn@digitalglobe.com> 1.2.1-1
 - Initial revision.


### PR DESCRIPTION
Upgrades `dumb-init` to 1.2.2 and improvements to the spec file:
* Use standard compilation and hardening flags like we do on rest of the RPMS (by using `sed` on the `Makefile` to allow override of the `CFLAGS`)
*  Remove deprecated metadata and fix nits in the description
* Include documentation files in RPM
