### PR TITLE
GNU Awk Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ To use this repository, you'll need the following:
 * Docker
 * Vagrant 2.0+
 * `make`
+* GNU Awk (`gawk` package on Ubuntu)
 
 For details on how to install these requirements on a Linux machine, read the
 [setup documentation](./docs/setup.md).

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -64,3 +64,14 @@ Make is used to manage the dependency graph between containers.
 In particular, some containers depend on RPMs built from different containers.
 For example, `rpmbuild-gdal` requires the GEOS RPM produced from
 `rpmbuild-geos`.
+
+## GNU Awk
+
+GNU's `awk` implementation is required due to the syntax of expressions
+used by the `Makefile`.  By default, GNU Awk is installed on all CentOS
+systems and Ubuntu releases prior to 18.04.  On Ubuntu 18.04 and above,
+install the `gawk` package:
+
+```
+sudo apt-get -y install gawk
+```


### PR DESCRIPTION
Added documentation about how GNU Awk is required.  This is necessary now since Ubuntu 18.04+ has been shipping without using it as the default `awk` implementation.