### PR TITLE
NodeJS 8.9.3-2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   lint:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/rpmbuild-lint@sha256:105824d72d650b30a404ea3197c28b2c341c0a033ac2f20456e97a702d2a3baa
+      - image: hootenanny/rpmbuild-lint@sha256:73203c65ae0b4b299f00c88195e7039c3676668517527ff59704a7690ddaf265
         user: rpmbuild
     steps:
       - checkout
@@ -52,7 +52,7 @@ jobs:
   master-install:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/run-base-release@sha256:40fb04610bc0e3317f5a7c7cef95b49b1996863c3323f4ab6fc316a9526f9cc0
+      - image: hootenanny/run-base-release@sha256:229a907137ad8ce789b84a343d0014401b1ba8b4114e3762bfb09ce37776ecd3
     steps:
       - checkout
       - attach_workspace:
@@ -64,7 +64,7 @@ jobs:
   master-upgrade:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/run-base-release@sha256:40fb04610bc0e3317f5a7c7cef95b49b1996863c3323f4ab6fc316a9526f9cc0
+      - image: hootenanny/run-base-release@sha256:229a907137ad8ce789b84a343d0014401b1ba8b4114e3762bfb09ce37776ecd3
     steps:
       - checkout
       - attach_workspace:
@@ -76,7 +76,7 @@ jobs:
   master-sync:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/rpmbuild-repo@sha256:27c86924043bae5d291bbc203702d2b2ed9f6970d9647462ecb8c73df5e012b4
+      - image: hootenanny/rpmbuild-repo@sha256:8717a75726db4a38977977f08344510bd15515aba4e344fd51f96f39b4f9fa75
         user: rpmbuild
     steps:
       - checkout

--- a/SPECS/nodejs.spec
+++ b/SPECS/nodejs.spec
@@ -42,12 +42,6 @@
 %global c_ares_patch 1
 %global c_ares_version %{c_ares_major}.%{c_ares_minor}.%{c_ares_patch}
 
-# http-parser - from deps/http_parser/http_parser.h
-%global http_parser_major 2
-%global http_parser_minor 7
-%global http_parser_patch 0
-%global http_parser_version %{http_parser_major}.%{http_parser_minor}.%{http_parser_patch}
-
 # libuv - from deps/uv/include/uv-version.h
 %global libuv_major 1
 %global libuv_minor 15
@@ -205,11 +199,17 @@ The API documentation for the Node.js JavaScript runtime.
 
 # remove bundled dependencies that we aren't building
 %patch1 -p1
-rm -rf deps/openssl \
-       deps/zlib
+%{__rm} -rf \
+ deps/http_parser \
+ deps/openssl \
+ deps/zlib
 
 %patch2 -p1
 %patch3 -p1
+
+# Remove hard-coded http_parser.gyp target from Makefile.
+%{__sed} -i -e 's|deps/http_parser/http_parser.gyp||' Makefile
+
 
 %build
 # build with debugging symbols and add defines from libuv (#892601)
@@ -399,5 +399,8 @@ NODE_PATH=%{buildroot}%{_prefix}/lib/node_modules %{buildroot}/%{_bindir}/node -
 %{_pkgdocdir}/html
 
 %changelog
+* Thu Mar 26 2020 Justin Bronn <justin.bronn@maxar.com> - 8.9.3-2
+- Rebuild for using the shared http-parser shared library.
+
 * Tue Jan 30 2018 Justin Bronn <justin.bronn@digitalglobe.com> - 8.9.3-1
 - Initial Release, includes shared library and bundled NPM.

--- a/config.yml
+++ b/config.yml
@@ -14,7 +14,7 @@ versions:
   libphonenumber: &libphonenumber_version '8.9.16-1'
   libpostal: &libpostal_version '1.0.0-1'
   mocha: &mocha_version '3.5.3'
-  nodejs: &nodejs_version '8.9.3-1'
+  nodejs: &nodejs_version '8.9.3-2'
   osmosis: &osmosis_version '0.46-1'
   postgis: &postgis_version '2.4.4-2'
   postgresql: &pg_version '9.5'


### PR DESCRIPTION
Creates a new release of NodeJS:
* Explicitly remove the `http_parser` from its bundled dependencies, forcing use of the `http-parser` shared library from CentOS.  This should fix issues with installing Mocha and accepting POST data due to updates that fixed [CVE-2019-15605](https://access.redhat.com/security/cve/cve-2019-15605).
* Upgrade NPM to 6.4.14.
* Remove debug compilation flags and update CircleCI images.

The updated RPM has been uploaded to our release dependency repository, and Docker images have been updated to include it.