### PR TITLE
Push first rpm build back to 0800 UTC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ workflows:
             - master-upgrade
     triggers:
       - schedule:
-          cron: "0 12,20 * * *"
+          cron: "0 8,20 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ workflows:
             - master-upgrade
     triggers:
       - schedule:
-          cron: "0 8,20 * * *"
+          cron: "0 8,17 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
This will allow hoot-testing to update it's rpm before anyone starts work in EST timezone, and the rpm update won't interrupt any running jobs in progress.

fixes #303 