### PR TITLE
Move morning rpm cron job to 0600 UTC (0100 EST)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ workflows:
             - master-upgrade
     triggers:
       - schedule:
-          cron: "0 8,17 * * *"
+          cron: "0 6,17 * * *"
           filters: &filters-master
             branches:
               only:


### PR DESCRIPTION
so that nightly box can rpm update won't miss the latest build.