### PR TITLE
Update NodeJS to lock with NPM version.

### DIFF
--- a/SPECS/nodejs.spec
+++ b/SPECS/nodejs.spec
@@ -239,8 +239,8 @@ Provides: bundled(histogram) = %{histogram_version}
 Requires: (nodejs-packaging if rpm-build)
 %endif
 
-# Make sure we keep NPM up to date when we update Node.js
-Requires: npm >= %{npm_epoch}:%{npm_version}-%{npm_release}%{?dist}
+# Make sure we lock NPM to version bundled with this NodeJS.
+Requires: npm = %{npm_epoch}:%{npm_version}-%{npm_release}%{?dist}
 
 %description
 Node.js is a platform built on Chrome's JavaScript runtime
@@ -679,5 +679,8 @@ end
 
 
 %changelog
+* Fri Jan 21 2022 Justin Bronn <justin.bronn@maxar.com> - 14.16.1-2
+- Lock NPM version together with NodeJS.
+
 * Thu May 20 2021 Benjamin Marchant <benjamin.marchant@maxar.com> 14.16.1-1
 - Build as shared module for Hootenanny

--- a/config.yml
+++ b/config.yml
@@ -7,7 +7,7 @@ versions:
   libphonenumber: &libphonenumber_version '8.12.27-1'
   libpostal: &libpostal_version '1.0.0-1'
   mocha: &mocha_version '3.5.3'
-  nodejs: &nodejs_version '14.16.1-1'
+  nodejs: &nodejs_version '14.16.1-2'
   postgresql: &pg_version '13'
   stxxl: &stxxl_version '1.3.1-1'
   hoot-translations-templates: &hoot_translations_templates_version '1.0.0-1'


### PR DESCRIPTION
Fixes #332.  Lock `npm` version along with `nodejs` release.  This will allow our existing releases of Hootenanny to work (as they're locked to NodeJS 14.16.1) but they'll get a release that won't try and install `npm` 8.