### PR TITLE
Lock v8-devel version

### DIFF
--- a/SPECS/nodejs.spec
+++ b/SPECS/nodejs.spec
@@ -26,10 +26,10 @@
 # v8 - from deps/v8/include/v8-version.h
 # Epoch is set to ensure clean upgrades from the old v8 package
 %global v8_epoch 2
-%global v8_major 8
-%global v8_minor 4
-%global v8_build 371
-%global v8_patch 19
+%global v8_major %(echo %{v8_version} | awk -F. '{ print $1 }')
+%global v8_minor %(echo %{v8_version} | awk -F. '{ print $2 }')
+%global v8_build %(echo %{v8_version} | awk -F. '{ print $3 }')
+%global v8_patch %(echo %{v8_version} | awk -F. '{ print $4 }')
 # V8 presently breaks ABI at least every x.y release while never bumping SONAME
 %global v8_abi %{v8_major}.%{v8_minor}
 %global v8_version %{v8_major}.%{v8_minor}.%{v8_build}.%{v8_patch}

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -158,6 +158,7 @@ def build_container(config, name, options)
           'rpmbuild_version' => '0.0.0',
           'rpmbuild_release' => '1',
           'tomcat_version' => '0.0.0',
+          'v8_version' => '0.0.0.0',
         }.each do |macro, expr|
           rpmspec_cmd << '--define'
           # Have to put in single quotes surrounding macro since this is a

--- a/config.yml
+++ b/config.yml
@@ -13,6 +13,7 @@ versions:
   hoot-translations-templates: &hoot_translations_templates_version '1.0.0-1'
   su-exec: &suexec_version '0.2-1'
   tomcat8: &tomcat8_version '8.5.66-1'
+  v8_version: &v8_version '8.4.371.19'
   wamerican-insane: &wamerican_version '7.1-1'
 
 
@@ -44,6 +45,7 @@ images:
           mocha_version: *mocha_version
           nodejs_version: *nodejs_version
           pg_version: *pg_version
+          v8_version: *v8_version
         buildrequires: true
         rpmbuild: true
         spec_file: SPECS/hootenanny.spec
@@ -99,6 +101,8 @@ rpms:
   nodejs:
     image: rpmbuild-nodejs
     version: *nodejs_version
+    defines:
+      v8_version: *v8_version
   stxxl:
     image: rpmbuild-generic
     version: *stxxl_version

--- a/docker/Dockerfile.rpmbuild-hoot-release
+++ b/docker/Dockerfile.rpmbuild-hoot-release
@@ -28,6 +28,7 @@ ARG nodejs_version
 ARG packages
 ARG pg_version
 ARG pg_data=/var/lib/pgsql/${pg_version}/data
+ARG v8_version
 
 # Have PostgreSQL data directory persist in environment variable.
 ENV PGDATA=${pg_data}
@@ -39,7 +40,7 @@ USER root
 COPY scripts/hoot-repo.sh scripts/geoint-repo.sh scripts/nodejs-install.sh /tmp/
 RUN /tmp/geoint-repo.sh && \
     /tmp/hoot-repo.sh && \
-    /tmp/nodejs-install.sh ${nodejs_version} && \
+    /tmp/nodejs-install.sh ${nodejs_version} ${v8_version} && \
     rm -f /tmp/*.sh && \
     npm install --silent -g mocha@${mocha_version}
 

--- a/scripts/nodejs-install.sh
+++ b/scripts/nodejs-install.sh
@@ -17,11 +17,14 @@ set -euo pipefail
 
 # Ensure the release is stripped from version.
 NODE_VERSION="$(echo "$1" | awk -F- '{ print $1 }')"
+V8_VERSION="${2}"
 
 # Install the specific version of NodeJS and the yum version locking plugin.
 yum install -q -y \
-    "nodejs-$NODE_VERSION" "nodejs-devel-$NODE_VERSION" \
+    "nodejs-${NODE_VERSION}" \
+    "nodejs-devel-${NODE_VERSION}" \
+    "v8-devel-${V8_VERSION}" \
     yum-plugin-versionlock
 
 # Version lock the NodeJS version to prevent inadvertent upgrades.
-yum versionlock nodejs nodejs-devel
+yum versionlock nodejs nodejs-devel v8-devel


### PR DESCRIPTION
Explicitly define `v8-devel` version and lock it like we do with NodeJS.