### PR TITLE
NodeJS Bundled Versions / Hootenanny Spec Fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
   master-install:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/run-base-release@sha256:0655f8f13e9b60c6958607f943e736dd6235772a66f28472ee6fd85f3c5486f7
+      - image: hootenanny/run-base-release@sha256:94b5df9bbe8231f35576c26cbb60c3610fa8680c29f2a5b87c684e8cac962a0d
     steps:
       - checkout
       - attach_workspace:
@@ -64,7 +64,7 @@ jobs:
   master-upgrade:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/run-base-release@sha256:0655f8f13e9b60c6958607f943e736dd6235772a66f28472ee6fd85f3c5486f7
+      - image: hootenanny/run-base-release@sha256:94b5df9bbe8231f35576c26cbb60c3610fa8680c29f2a5b87c684e8cac962a0d
     steps:
       - checkout
       - attach_workspace:

--- a/Makefile
+++ b/Makefile
@@ -317,6 +317,7 @@ RPMS/x86_64/hootenanny-%.rpm: .vagrant/machines/$(BUILD_IMAGE)/docker/id
 	  --define "nodejs_version %(rpm -q --queryformat '%%{version}' nodejs)" \
 	  --define "stxxl_version %(rpm -q --queryformat '%%{version}' stxxl)" \
 	  --define "tomcat_version %(rpm -q --queryformat '%%{version}' tomcat8)" \
+	  --define "v8_version %(rpm -q --queryformat '%%{version}' v8-devel)" \
 	  -bb SPECS/hootenanny.spec
 
 # Runs container and follow logs until it completes.

--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -70,7 +70,7 @@
 %global __provides_exclude ^libgdal\\.so.*$
 
 # Use explicit requirements for libgdal and libpq.
-%global __requires_exclude ^lib(gdal|pq)\\.so.*$
+%global __requires_exclude ^(/usr/bin/node|lib(gdal|pq)\\.so.*)$
 
 Name:       hootenanny
 Version:    %{hoot_version}

--- a/SPECS/hootenanny.spec
+++ b/SPECS/hootenanny.spec
@@ -826,7 +826,7 @@ Requires:  python-argparse
 Requires:  python-devel
 Requires:  qt5-qtbase-devel
 Requires:  stxxl-devel = %{stxxl_version}
-Requires:  v8-devel
+Requires:  v8-devel = %{v8_version}
 # Documentation and report-related dependencies.
 Requires:  doxygen
 Requires:  liberation-fonts-common

--- a/SPECS/nodejs.spec
+++ b/SPECS/nodejs.spec
@@ -23,7 +23,18 @@
 %global nodejs_datadir %{_datarootdir}/nodejs
 
 # == Bundled Dependency Versions ==
-# v8 - from deps/v8/include/v8-version.h
+# The following macros are required:
+#  * c_ares_version:    deps/cares/include/ares_version.h
+#  * histogram_version: assumed from timestamps
+#  * icu_version:       tools/icu/current_ver.dep
+#  * libuv_version:     deps/uv/include/uv/version.h
+#  * llhttp_version:    deps/llhttp/include/llhttp.h44
+#  * nghttp2_version:   deps/nghttp2/lib/includes/nghttp2/nghttp2ver.h
+#  * npm_version:       deps/npm/package.json
+#  * punycode_version:  lib/punycode.js
+#  * uvwasi:            deps/uvwasi/include/uvwasi.h
+#  * v8_version:        deps/v8/include/v8-version.h
+#
 # Epoch is set to ensure clean upgrades from the old v8 package
 %global v8_epoch 2
 %global v8_major %(echo %{v8_version} | awk -F. '{ print $1 }')
@@ -32,78 +43,23 @@
 %global v8_patch %(echo %{v8_version} | awk -F. '{ print $4 }')
 # V8 presently breaks ABI at least every x.y release while never bumping SONAME
 %global v8_abi %{v8_major}.%{v8_minor}
-%global v8_version %{v8_major}.%{v8_minor}.%{v8_build}.%{v8_patch}
 %global v8_release %{nodejs_epoch}.%{nodejs_major}.%{nodejs_minor}.%{nodejs_patch}.%{nodejs_release}
 
-# c-ares - from deps/cares/include/ares_version.h
-# https://github.com/nodejs/node/pull/9332
-%global c_ares_major 1
-%global c_ares_minor 16
-%global c_ares_patch 1
-%global c_ares_version %{c_ares_major}.%{c_ares_minor}.%{c_ares_patch}
-
-# llhttp - from deps/llhttp/include/llhttp.h
-%global llhttp_major 2
-%global llhttp_minor 1
-%global llhttp_patch 3
-%global llhttp_version %{llhttp_major}.%{llhttp_minor}.%{llhttp_patch}
-
-# libuv - from deps/uv/include/uv/version.h
-%global libuv_major 1
-%global libuv_minor 40
-%global libuv_patch 0
-%global libuv_version %{libuv_major}.%{libuv_minor}.%{libuv_patch}
-
-# nghttp2 - from deps/nghttp2/lib/includes/nghttp2/nghttp2ver.h
-%global nghttp2_major 1
-%global nghttp2_minor 41
-%global nghttp2_patch 0
-%global nghttp2_version %{nghttp2_major}.%{nghttp2_minor}.%{nghttp2_patch}
-
-# ICU - from tools/icu/current_ver.dep
-%global icu_major 67
-%global icu_minor 1
-%global icu_version %{icu_major}.%{icu_minor}
-
+# ICU
+%global icu_major %(echo %{icu_version} | awk -F. '{ print $1 }')
+%global icu_minor %(echo %{icu_version} | awk -F. '{ print $2 }')
 %global icudatadir %{nodejs_datadir}/icudata
 %{!?little_endian: %global little_endian %(%{__python3} -c "import sys;print (0 if sys.byteorder=='big' else 1)")}
 # " this line just fixes syntax highlighting for vim that is confused by the above and continues literal
 
-
 # OpenSSL minimum version
 %global openssl_minimum 1:1.1.1
-
-# punycode - from lib/punycode.js
-# Note: this was merged into the mainline since 0.6.x
-# Note: this will be unmerged in an upcoming major release
-%global punycode_major 2
-%global punycode_minor 1
-%global punycode_patch 0
-%global punycode_version %{punycode_major}.%{punycode_minor}.%{punycode_patch}
-
-# npm - from deps/npm/package.json
-%global npm_epoch 1
-%global npm_major 6
-%global npm_minor 14
-%global npm_patch 12
-%global npm_version %{npm_major}.%{npm_minor}.%{npm_patch}
-
-# uvwasi - from deps/uvwasi/include/uvwasi.h
-%global uvwasi_major 0
-%global uvwasi_minor 0
-%global uvwasi_patch 11
-%global uvwasi_version %{uvwasi_major}.%{uvwasi_minor}.%{uvwasi_patch}
-
-# histogram_c - assumed from timestamps
-%global histogram_major 0
-%global histogram_minor 9
-%global histogram_patch 7
-%global histogram_version %{histogram_major}.%{histogram_minor}.%{histogram_patch}
 
 # In order to avoid needing to keep incrementing the release version for the
 # main package forever, we will just construct one for npm that is guaranteed
 # to increment safely. Changing this can only be done during an update when the
 # base npm version number is increasing.
+%global npm_epoch 1
 %global npm_release %{nodejs_epoch}.%{nodejs_major}.%{nodejs_minor}.%{nodejs_patch}.%{nodejs_release}
 
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -158,6 +158,15 @@ def build_container(config, name, options)
           'rpmbuild_version' => '0.0.0',
           'rpmbuild_release' => '1',
           'tomcat_version' => '0.0.0',
+          'c_ares_version' => '0.0.0',
+          'histogram_version' => '0.0.0',
+          'icu_version' => '0.0',
+          'libuv_version' => '0.0.0',
+          'llhttp_version' => '0.0.0',
+          'nghttp2_version' => '0.0.0',
+          'npm_version' => '0.0.0',
+          'punycode_version' => '0.0.0',
+          'uvwasi_version' => '0.0.0',
           'v8_version' => '0.0.0.0',
         }.each do |macro, expr|
           rpmspec_cmd << '--define'

--- a/config.yml
+++ b/config.yml
@@ -83,6 +83,7 @@ images:
         args:
           mocha_version: *mocha_version
           nodejs_version: *nodejs_version
+          v8_version: *v8_version
 
 rpms:
   glpk:

--- a/config.yml
+++ b/config.yml
@@ -8,12 +8,22 @@ versions:
   libpostal: &libpostal_version '1.0.0-1'
   mocha: &mocha_version '3.5.3'
   nodejs: &nodejs_version '14.16.1-2'
+  nodejs_bundled_versions: &nodejs_bundled_versions
+    c_ares_version: '1.16.1'
+    histogram_version: '0.9.7'
+    icu_version: '67.1'
+    libuv_version: '1.40.0'
+    llhttp_version: '2.1.3'
+    nghttp2_version: '1.41.0'
+    npm_version: '6.14.12'
+    punycode_version: '2.1.0'
+    uvwasi_version: '0.0.11'
+    v8_version: &v8_version '8.4.371.19'
   postgresql: &pg_version '13'
   stxxl: &stxxl_version '1.3.1-1'
   hoot-translations-templates: &hoot_translations_templates_version '1.0.0-1'
   su-exec: &suexec_version '0.2-1'
   tomcat8: &tomcat8_version '8.5.75-1'
-  v8_version: &v8_version '8.4.371.19'
   wamerican-insane: &wamerican_version '7.1-1'
 
 
@@ -102,7 +112,7 @@ rpms:
     image: rpmbuild-nodejs
     version: *nodejs_version
     defines:
-      v8_version: *v8_version
+      <<: *nodejs_bundled_versions
   stxxl:
     image: rpmbuild-generic
     version: *stxxl_version

--- a/docker/Dockerfile.run-base
+++ b/docker/Dockerfile.run-base
@@ -71,7 +71,6 @@ RUN yum-config-manager --save \
         qt5-qtbase-postgresql \
         qt5-qtx11extras \
         unzip \
-        v8 \
         w3m \
         wget \
         words \

--- a/docker/Dockerfile.run-base-release
+++ b/docker/Dockerfile.run-base-release
@@ -23,6 +23,7 @@ LABEL \
 ARG packages
 ARG mocha_version
 ARG nodejs_version
+ARG v8_version
 
 # Install Hootenanny dependency release repository and NodeJS.
 COPY scripts/hoot-repo.sh \
@@ -30,7 +31,7 @@ COPY scripts/hoot-repo.sh \
      /tmp/
 RUN /tmp/hoot-repo.sh && \
     rm /tmp/hoot-repo.sh && \
-    /tmp/nodejs-install.sh ${nodejs_version} && \
+    /tmp/nodejs-install.sh ${nodejs_version} ${v8_version} && \
     rm -f /tmp/nodejs-install.sh && \
     npm install --silent -g mocha@${mocha_version}
 

--- a/shell/BuildHoot.sh
+++ b/shell/BuildHoot.sh
@@ -39,4 +39,5 @@ run_hoot_build_image \
       --define "nodejs_version %(rpm -q --queryformat '%%{version}' nodejs)" \
       --define "stxxl_version %(rpm -q --queryformat '%%{version}' stxxl)" \
       --define "tomcat_version %(rpm -q --queryformat '%%{version}' tomcat8)" \
+      --define "v8_version %(rpm -q --queryformat '%%{version}' v8)" \
       -bb SPECS/hootenanny.spec

--- a/shell/BuildHoot.sh
+++ b/shell/BuildHoot.sh
@@ -39,5 +39,5 @@ run_hoot_build_image \
       --define "nodejs_version %(rpm -q --queryformat '%%{version}' nodejs)" \
       --define "stxxl_version %(rpm -q --queryformat '%%{version}' stxxl)" \
       --define "tomcat_version %(rpm -q --queryformat '%%{version}' tomcat8)" \
-      --define "v8_version %(rpm -q --queryformat '%%{version}' v8)" \
+      --define "v8_version %(rpm -q --queryformat '%%{version}' v8-devel)" \
       -bb SPECS/hootenanny.spec


### PR DESCRIPTION
* Track all NodeJS bundled versions in configuration like done with v8.
* Lock `v8-devel` version for `core-devel-deps`.
* Exclude `/usr/bin/node` from generating automatic requirements.
* Fix v8 issues with the runtime containers (uses in RPM tests).