### PR TITLE
Hoot Release Fix & CircleCI Image Updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   lint:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/rpmbuild-lint@sha256:e54184398548d02abc7552bb49b7c2dae8aa554ae10760837162b1477ba87465
+      - image: hootenanny/rpmbuild-lint@sha256:0d554c52e05243a0cc54fb0c0ffc2c46a237e3d384e07cf92ec52627d0822745
         user: rpmbuild
     steps:
       - checkout
@@ -54,7 +54,7 @@ jobs:
   master-install:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/run-base-release@sha256:94b5df9bbe8231f35576c26cbb60c3610fa8680c29f2a5b87c684e8cac962a0d
+      - image: hootenanny/run-base-release@sha256:770afcafbc2e1c21ef76ddd4a3c3fb45df6f9a3be7d09a25dab29ac914b1121f
     steps:
       - checkout
       - attach_workspace:
@@ -66,7 +66,7 @@ jobs:
   master-upgrade:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/run-base-release@sha256:94b5df9bbe8231f35576c26cbb60c3610fa8680c29f2a5b87c684e8cac962a0d
+      - image: hootenanny/run-base-release@sha256:770afcafbc2e1c21ef76ddd4a3c3fb45df6f9a3be7d09a25dab29ac914b1121f
     steps:
       - checkout
       - attach_workspace:
@@ -78,7 +78,7 @@ jobs:
   master-sync:
     working_directory: '/rpmbuild/hootenanny-rpms'
     docker:
-      - image: hootenanny/rpmbuild-repo@sha256:4108df08fe36d9dc573fd5d78919c6bedc7ad4bc29a74be5d9729111df28dd22
+      - image: hootenanny/rpmbuild-repo@sha256:5f4bb14e00a60ab66579edb2382135d5609ead01d5bde6f0a9cd0a3203a8d520
         user: rpmbuild
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ RUN_IMAGE ?= run-base-release
 HOOT_VERSION_GEN ?= $(call latest_hoot_version_gen)
 DEFAULT_ARCHIVE := SOURCES/hootenanny-archive.tar.gz
 
+HOOT_RELEASE ?= 1
 ifeq ($(strip $(HOOT_VERSION_GEN)),)
 # Setup a dummy archive file that will force making of an archive
 # from the revision specified in GIT_COMMIT.
@@ -145,7 +146,6 @@ else
 HOOT_ARCHIVE := SOURCES/hootenanny-$(HOOT_VERSION_GEN).tar.gz
 ifeq ($(strip $(call hoot_extra_version,$(HOOT_VERSION_GEN))),)
 # Release version (HOOT_VERSION_GEN=0.2.38).
-HOOT_RELEASE ?= 1
 HOOT_VERSION := $(call hoot_version_tag,$(HOOT_VERSION_GEN))-$(HOOT_RELEASE)
 else
 # Development version (HOOT_VERSION_GEN=0.2.38_23_gdadada1)
@@ -309,6 +309,7 @@ RPMS/x86_64/hootenanny-%.rpm: .vagrant/machines/$(BUILD_IMAGE)/docker/id
 	$(VAGRANT) docker-run $(BUILD_IMAGE) -- \
 	rpmbuild \
 	  --define "hoot_version_gen $(HOOT_VERSION_GEN)" \
+	  --define "hoot_release $(HOOT_RELEASE)" \
 	  --define "geos_version %(rpm -q --queryformat '%%{version}' geos)" \
 	  --define "gdal_version %(rpm -q --queryformat '%%{version}' gdal)" \
 	  --define "glpk_version %(rpm -q --queryformat '%%{version}' glpk)" \

--- a/docker/Dockerfile.rpmbuild-pgdg
+++ b/docker/Dockerfile.rpmbuild-pgdg
@@ -33,15 +33,15 @@ USER root
 COPY scripts/pgdg-repo.sh /tmp/pgdg-repo.sh
 RUN /tmp/pgdg-repo.sh ${pg_version} && \
     rm /tmp/pgdg-repo.sh && \
-    yum -q -y install postgresql$(echo $pg_version | awk '{ gsub(/\./, ""); print substr($0, 1, 2) }')-devel && \
-    alternatives --install /usr/bin/pg_config pgsql-pg_config /usr/pgsql-$(echo $pg_version | awk -F. '{ if ($1 >= 10) print $1; else print $0 }')/bin/pg_config 500 && \
-    if [ ! -z "${packages}" ] ; then yum -q -y install ${packages}; fi && \
+    yum -q -y install postgresql${pg_version}-devel && \
+    alternatives --install /usr/bin/pg_config pgsql-pg_config /usr/pgsql-${pg_version}/bin/pg_config 500 && \
+    if [ -n "${packages:-}" ]; then yum -q -y install ${packages}; fi && \
     yum -q -y clean all
 
 # Switch back to RPM build user.
 USER ${RPMBUILD_USER}
 
 # Add in RPM macros necessary for creating Hootenanny and GDAL packages.
-RUN echo "%pg_version ${PG_VERSION}" >> $RPMBUILD_HOME/.rpmmacros && \
-    echo "%pg_dotless %(echo %{pg_version} | awk '{ gsub(/\\\\./, \"\"); print substr(\$0, 1, 2) }')" >> $RPMBUILD_HOME/.rpmmacros && \
-    echo "%pginstdir /usr/pgsql-%{pg_version}" >> $RPMBUILD_HOME/.rpmmacros
+RUN echo "%pg_version ${PG_VERSION}" >> ${RPMBUILD_HOME}/.rpmmacros && \
+    echo "%pg_dotless ${PG_VERSION}" >> ${RPMBUILD_HOME}/.rpmmacros && \
+    echo "%pginstdir /usr/pgsql-%{pg_version}" >> ${RPMBUILD_HOME}/.rpmmacros

--- a/scripts/geoint-repo.sh
+++ b/scripts/geoint-repo.sh
@@ -15,8 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 set -euo pipefail
 
+source /etc/os-release
 GEOINT_DEPS_CHANNEL="${GEOINT_DEPS_CHANNEL:-stable}"
-GEOINT_DEPS_BASEURL="${GEOINT_DEPS_BASEURL:-https://geoint-deps.s3.amazonaws.com/el7/${GEOINT_DEPS_CHANNEL}}"
+GEOINT_DEPS_BASEURL="${GEOINT_DEPS_BASEURL:-https://geoint-deps.s3.amazonaws.com/el${VERSION_ID}/${GEOINT_DEPS_CHANNEL}}"
 GEOINT_DEPS_KEY="${GEOINT_DEPS_KEY:-/etc/pki/rpm-gpg/RPM-GPG-KEY-GEOINT}"
 GEOINT_DEPS_REPO="${GEOINT_DEPS_REPO:-/etc/yum.repos.d/geoint-deps.repo}"
 
@@ -53,7 +54,7 @@ BKvRcPtz0vU2ZA+JjgCXqpu0sLpMY/CGlgn9m4XlZYQ8ok/fe1no7k6cJat1EHLH
 EOF
 
 cat > "${GEOINT_DEPS_REPO}" <<EOF
-[geoint-deps]
+[geoint-deps-${GEOINT_DEPS_CHANNEL}]
 name = GEOINT Dependencies
 baseurl = ${GEOINT_DEPS_BASEURL}
 enable = 1

--- a/scripts/pgdg-repo.sh
+++ b/scripts/pgdg-repo.sh
@@ -16,13 +16,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 set -euo pipefail
 
-PG_VERSION="$1"
-PG_DOTLESS="$(echo "$PG_VERSION" | awk '{ gsub(/\./, ""); print substr($0, 1, 2) }')"
-PG_MAJOR_VERSION="$(echo "$PG_VERSION" | awk -F. '{ if ($1 >= 10) print $1; else print $0 }')"
-PGDG_KEY="${PGDG_KEY:-/etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-$PG_DOTLESS}"
-PGDG_REPO="${PGDG_REPO:-/etc/yum.repos.d/pgdg-$PG_DOTLESS-centos.repo}"
+POSTGRES_VERSION="${1}"
+PGDG_KEY="${PGDG_KEY:-/etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG}"
+PGDG_REPO="${PGDG_REPO:-/etc/yum.repos.d/pgdg-${POSTGRES_VERSION}-centos.repo}"
+PGDG_BASEURL="https://download.postgresql.org/pub/repos/yum"
+if [ "${POSTGRES_VERSION}" -ge 15 ]; then
+    PGDG_BASEURL="${PGDG_BASEURL}/testing"
+fi
 
-cat > "$PGDG_KEY" <<EOF
+cat > "${PGDG_KEY}" <<EOF
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1.4.7 (GNU/Linux)
 
@@ -55,19 +57,21 @@ GaCXCY8h3xi6VIhJBBgRAgAJBQJHg/JKAhsMAAoJEB8W0uFELfD4K4cAoJ4yug8y
 -----END PGP PUBLIC KEY BLOCK-----
 EOF
 
-cat > "$PGDG_REPO" <<EOF
-[pgdg$PG_DOTLESS]
-name=PostgreSQL $PG_MAJOR_VERSION \$releasever - \$basearch
-baseurl=https://download.postgresql.org/pub/repos/yum/$PG_MAJOR_VERSION/redhat/rhel-\$releasever-\$basearch
+cat > "${PGDG_REPO}" <<EOF
+[pgdg${POSTGRES_VERSION}]
+name=PostgreSQL ${POSTGRES_VERSION} \$releasever - \$basearch
+baseurl=${PGDG_BASEURL}/${POSTGRES_VERSION}/redhat/rhel-\$releasever-\$basearch
 enabled=1
 gpgcheck=1
-gpgkey=file://$PGDG_KEY
+gpgkey=file://${PGDG_KEY}
+repo_gpgcheck=1
 
-[pgdg$PG_DOTLESS-source]
-name=PostgreSQL $PG_MAJOR_VERSION \$releasever - \$basearch - Source
+[pgdg${POSTGRES_VERSION}-source]
+name=PostgreSQL ${POSTGRES_VERSION} \$releasever - \$basearch - Source
 failovermethod=priority
-baseurl=https://download.postgresql.org/pub/repos/yum/srpms/$PG_MAJOR_VERSION/redhat/rhel-\$releasever-\$basearch
+baseurl=${PGDG_BASEURL}/srpms/${POSTGRES_VERSION}/redhat/rhel-\$releasever-\$basearch
 enabled=0
 gpgcheck=1
-gpgkey=file://$PGDG_KEY
+gpgkey=file://${PGDG_KEY}
+repo_gpgcheck=1
 EOF


### PR DESCRIPTION
* Respect `HOOT_RELEASE` environment variable so it's possible to create an iteration release, e.g. for `0.2.72-2`:
    ```
    HOOT_RELEASE=2 HOOT_VERSION_GEN=0.2.72 make rpm
    ```
* Update CircleCI images to latest versions.
* Updates to `pgdg-repo.sh` (check metadata signatures, support testing repository) and `geoint-deps.sh` (EL9, make repo name cache friendly).
* Minor cleanup of `Dockerfile.rpmbuild-pgdg`