### PR TITLE
Upgrade LibPostal from v1.0.0 to v1.1

### DIFF
--- a/SOURCES/libpostal-configure.patch
+++ b/SOURCES/libpostal-configure.patch
@@ -49,7 +49,7 @@ index b35f611..58dd670 100644
  
 @@ -11,4 +8,4 @@ TESTS = test_libpostal
  noinst_PROGRAMS = test_libpostal
- test_libpostal_SOURCES = test.c test_expand.c test_parser.c test_transliterate.c test_numex.c test_trie.c test_string_utils.c test_crf_context.c
- test_libpostal_LDADD = ../src/libpostal.la $(CBLAS_LIBS)
+ test_libpostal_SOURCES = test.c test_expand.c test_parser.c test_transliterate.c test_numex.c test_trie.c test_string_utils.c test_crf_context.c ../src/strndup.c ../src/file_utils.c ../src/string_utils.c ../src/utf8proc/utf8proc.c ../src/trie.c ../src/trie_search.c ../src/transliterate.c ../src/numex.c ../src/features.c
+ test_libpostal_LDADD = ../src/libpostal.la ../src/libscanner.la $(CBLAS_LIBS)
 -test_libpostal_CFLAGS = $(CFLAGS_O3)
 +test_libpostal_CFLAGS = $(CFLAGS_BASE)

--- a/SPECS/libpostal.spec
+++ b/SPECS/libpostal.spec
@@ -28,6 +28,11 @@
 # This will make compilation take a *long* time (~1 hour).
 %bcond_with optimize_scanner
 
+# The latest version of libpostal doesn't provide a new version of parser,
+# language_classifier, or libpostal_data, grab them from a previous version
+%global parser_version 1.0.0
+
+
 Name:           libpostal
 Version:        %{rpmbuild_version}
 Release:        %{rpmbuild_release}%{?dist}
@@ -35,18 +40,16 @@ Group:          Applications/Engineering
 Summary:        C library for parsing/normalizing street addresses around the world
 License:        MIT
 URL:            https://github.com/openvenues/libpostal/
-Source0:        https://github.com/openvenues/libpostal/archive/v%{version}/libpostal-%{version}.tar.gz
-Source1:        https://github.com/openvenues/libpostal/releases/download/v%{version}/parser.tar.gz
-Source2:        https://github.com/openvenues/libpostal/releases/download/v%{version}/language_classifier.tar.gz
-Source3:        https://github.com/openvenues/libpostal/releases/download/v%{version}/libpostal_data.tar.gz
+Source0:        https://github.com/openvenues/libpostal/archive/refs/tags/v%{version}.tar.gz
+Source1:        https://github.com/openvenues/libpostal/releases/download/v%{parser_version}/parser.tar.gz
+Source2:        https://github.com/openvenues/libpostal/releases/download/v%{parser_version}/language_classifier.tar.gz
+Source3:        https://github.com/openvenues/libpostal/releases/download/v%{parser_version}/libpostal_data.tar.gz
 
 # Modify build system to accomodate RPM build flags.
 Patch0:         libpostal-configure.patch
-
 # Calling `crf_context_destroy` at end of tests will cause a segfault,
 # must patch in order to run the test suite.
 Patch1:         libpostal-tests-fix.patch
-
 # Don't use -O0 when compiling the scanner.
 Patch2:         libpostal-optimize-scanner.patch
 
@@ -136,5 +139,7 @@ find %{buildroot}%{libpostal_data} -maxdepth 1 -type d -exec ln -s {} %{libposta
 
 
 %changelog
+* Wed Oct 12 2022 Ben Marchant <benjamin.marchant@maxar.com> - 1.1-1
+- Updated release, 1.1
 * Thu Nov 08 2018 Justin Bronn <justin.bronn@radiantsolutions.com> - 1.0.0-1
 - Initial release, 1.0.0.

--- a/config.yml
+++ b/config.yml
@@ -5,7 +5,7 @@ versions:
   lcov: &lcov_version '1.15-1'
   liboauthcpp: &liboauthcpp_version '0.1.0-1'
   libphonenumber: &libphonenumber_version '8.12.39-1'
-  libpostal: &libpostal_version '1.0.0-1'
+  libpostal: &libpostal_version '1.1-1'
   mocha: &mocha_version '3.5.3'
   nodejs: &nodejs_version '14.16.1-2'
   nodejs_bundled_versions: &nodejs_bundled_versions


### PR DESCRIPTION
LibPostal's latest release is a bit different than prior releases.  The source code location is different and the name of the tar file is non-standard.  The parser, classifier, and data source code tar files weren't updated at all for this release and weren't included in the release so they had to come from the prior release.  There were also changes in the test Makefile that required an updated patch.