### PR TITLE
get ubuntu key

### DIFF
--- a/scripts/rpm-install.sh
+++ b/scripts/rpm-install.sh
@@ -23,6 +23,7 @@ if [ "$LSB_DIST" == 'centos' -o "$LSB_DIST" == 'fedora' -o "$LSB_DIST" == 'rhel'
 elif [ "$LSB_DIST" == 'debian' -o "$LSB_DIST" == 'ubuntu' ]; then
     count=0
     timeout=180
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D155B8E6A419C5BE
     while fuser /var/lib/dpkg/lock ; do
         sleep 1
         ((count = count + 1))


### PR DESCRIPTION
Was previously getting this error on Ubuntu 20.04 when running `./scripts/rpm-install.sh`
```
W: GPG error: https://ubuntugis.qgis.org/ubuntugis focal InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY D155B8E6A419C5BE
E: The repository 'https://qgis.org/ubuntugis focal InRelease' is not signed.
```
https://askubuntu.com/questions/13065/how-do-i-fix-the-gpg-error-no-pubkey